### PR TITLE
Fix aico missing f2c

### DIFF
--- a/exotations/solvers/aico/CMakeLists.txt
+++ b/exotations/solvers/aico/CMakeLists.txt
@@ -13,7 +13,6 @@ add_definitions(-DEXOTICA_DEBUG_MODE)  #Controls whether to compile with certain
 find_package(catkin REQUIRED COMPONENTS
   exotica
   roscpp
-  roslib
   task_definition
   task_map
 )
@@ -25,7 +24,7 @@ find_package(LAPACK REQUIRED)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES aico
-  CATKIN_DEPENDS exotica roscpp roslib task_definition task_map
+  CATKIN_DEPENDS exotica roscpp task_definition task_map
   DEPENDS system_lib
 )
 

--- a/exotations/solvers/aico/package.xml
+++ b/exotations/solvers/aico/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>exotica</build_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>roslib</build_depend>
   <build_depend>task_definition</build_depend>
   <build_depend>task_map</build_depend>
   <build_depend>liblapack-dev</build_depend>
@@ -21,7 +20,6 @@
 
   <run_depend>exotica</run_depend>
   <run_depend>roscpp</run_depend>
-  <run_depend>roslib</run_depend>
   <run_depend>task_definition</run_depend>
   <run_depend>task_map</run_depend>
   <run_depend>liblapack-dev</run_depend>

--- a/exotations/solvers/aico/package.xml
+++ b/exotations/solvers/aico/package.xml
@@ -8,7 +8,7 @@
 
   <license>BSD</license>
 
-  <url type="website">https://bitbucket.org/IPAB-SLMC/exotica</url>
+  <url type="website">https://github.com/openhumanoids/exotica</url>
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>exotica</build_depend>
@@ -25,13 +25,4 @@
   <run_depend>liblapack-dev</run_depend>
   <run_depend>f2c</run_depend>
 
-
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- You can specify that this package is a metapackage here: -->
-    <!-- <metapackage/> -->
-
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
 </package>

--- a/exotations/solvers/aico/package.xml
+++ b/exotations/solvers/aico/package.xml
@@ -17,6 +17,7 @@
   <build_depend>task_definition</build_depend>
   <build_depend>task_map</build_depend>
   <build_depend>liblapack-dev</build_depend>
+  <build_depend>f2c</build_depend>
 
   <run_depend>exotica</run_depend>
   <run_depend>roscpp</run_depend>
@@ -24,6 +25,7 @@
   <run_depend>task_definition</run_depend>
   <run_depend>task_map</run_depend>
   <run_depend>liblapack-dev</run_depend>
+  <run_depend>f2c</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
Probably I'm the first one to compile exotica on a setup that doesn't have f2c installed. This revealed that it is missing from the dependencies of the aico solver, so I took care of that.

Now running 
`rosdep install --from-paths src --ignore-src --rosdistro indigo -y`
in the root of a catkin workspace should install all dependencies the exotica repo needs even for those who are like me :)