### PR TITLE
fixed state slef-collision check function

### DIFF
--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -378,10 +378,13 @@ namespace exotica
     stateCheckCnt_++;
     collision_detection::CollisionRequest req;
     collision_detection::CollisionResult res;
-    ps_->checkSelfCollision(req, res, ps_->getCurrentState(), *acm_);
-    if (res.collision)
+    if (self)
     {
-      return false;
+      ps_->checkSelfCollision(req, res, ps_->getCurrentState(), *acm_);
+      if (res.collision)
+      {
+        return false;
+      }
     }
     req.contacts = false;
     if (dist > 0) req.distance = true;


### PR DESCRIPTION
added ignore self-collision check in exotica scene, to allow simple one arm planning to work on dual arm husky