### PR TITLE
fix self collision check in exotica scene

### DIFF
--- a/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLBaseStateSpace.h
+++ b/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLBaseStateSpace.h
@@ -74,6 +74,7 @@ namespace exotica
     protected:
       OMPLProblem_ptr prob_;
       EParam<std_msgs::Float64> margin_;
+      EParam<std_msgs::Bool> self_collision_;
   };
 
 } /* namespace exotica */

--- a/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLBaseStateSpace.cpp
+++ b/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLBaseStateSpace.cpp
@@ -54,6 +54,14 @@ namespace exotica
       margin_->data = 0.0;
       server->setParam(server->getName() + "/SafetyMargin", margin_);
     }
+    if (server->hasParam(server->getName() + "/SelfCollisionCheck"))
+      server->getParam(server->getName() + "/SelfCollisionCheck", self_collision_);
+    else
+    {
+      self_collision_.reset(new std_msgs::Bool());
+      self_collision_->data = false;
+      server->setParam(server->getName() + "/SelfCollisionCheck", self_collision_);
+    }
 
     HIGHLIGHT_NAMED("OMPLStateValidityChecker",
         "Safety Margin: " << margin_->data);
@@ -73,7 +81,7 @@ namespace exotica
         state, q);
     boost::mutex::scoped_lock lock(prob_->getLock());
     prob_->update(q, 0);
-    if (!prob_->getScene()->getCollisionScene()->isStateValid(0, margin_->data))
+    if (!prob_->getScene()->getCollisionScene()->isStateValid(self_collision_->data, margin_->data))
     {
       dist = -1;
       return false;


### PR DESCRIPTION
－ The OMPL solver use to ignore self-collisions, now is fixed.