### PR TITLE
Adds support for different robot_description parameter name.

### DIFF
--- a/exotations/task_maps/task_map/src/JointLimit.cpp
+++ b/exotations/task_maps/task_map/src/JointLimit.cpp
@@ -59,8 +59,17 @@ namespace exotica
     int size = jnts.size();
     low_limits_.resize(size);
     high_limits_.resize(size);
-    robot_model::RobotModelConstPtr model = server_->getModel(
-        "robot_description");
+
+    robot_model::RobotModelConstPtr model;
+    if (server_->hasParam("RobotDescription")) {
+      EParam<std_msgs::String> robot_description_param;
+      server_->getParam("RobotDescription", robot_description_param);
+      ROS_INFO_STREAM("Loading joint limits for robot_description at " << robot_description_param->data);
+      model = server_->getModel(robot_description_param->data);
+    } else {
+      model = server_->getModel("robot_description");
+    }
+
     for (int i = 0; i < jnts.size(); i++)
     {
       low_limits_(i) =

--- a/exotations/task_maps/task_map/src/JointLimit.cpp
+++ b/exotations/task_maps/task_map/src/JointLimit.cpp
@@ -66,6 +66,11 @@ namespace exotica
       server_->getParam("RobotDescription", robot_description_param);
       ROS_INFO_STREAM("Loading joint limits for robot_description at " << robot_description_param->data);
       model = server_->getModel(robot_description_param->data);
+    } else if (server_->hasParam(server_->getName() + "/RobotDescription")) {
+      EParam<std_msgs::String> robot_description_param;
+      server_->getParam(server_->getName() + "/RobotDescription", robot_description_param);
+      ROS_INFO_STREAM("Loading joint limits for robot_description at " << robot_description_param->data);
+      model = server_->getModel(robot_description_param->data);
     } else {
       model = server_->getModel("robot_description");
     }

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -191,6 +191,13 @@ namespace exotica
       ps_.reset(
         new planning_scene::PlanningScene(
             server_->getModel(robot_description_param->data)));
+    } else if (server_->hasParam(server_->getName() + "/RobotDescription")) {
+      EParam<std_msgs::String> robot_description_param;
+      server_->getParam(server_->getName() + "/RobotDescription", robot_description_param);
+      ROS_INFO_STREAM("Loading collision scene for robot_description at " << robot_description_param->data);
+      ps_.reset(
+        new planning_scene::PlanningScene(
+            server_->getModel(robot_description_param->data)));
     } else {
       ps_.reset(
         new planning_scene::PlanningScene(
@@ -641,6 +648,11 @@ namespace exotica
     if (server_->hasParam("RobotDescription")) {
       EParam<std_msgs::String> robot_description_param;
       server_->getParam("RobotDescription", robot_description_param);
+      ROS_INFO_STREAM("Using robot_description at " << robot_description_param->data);
+      server->getModel(robot_description_param->data, model_);
+    } else if (server_->hasParam(server_->getName() + "/RobotDescription")) {
+      EParam<std_msgs::String> robot_description_param;
+      server_->getParam(server_->getName() + "/RobotDescription", robot_description_param);
       ROS_INFO_STREAM("Using robot_description at " << robot_description_param->data);
       server->getModel(robot_description_param->data, model_);
     } else {

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -184,9 +184,19 @@ namespace exotica
       const std::vector<std::string> & joints, std::string & mode,
       BASE_TYPE base_type)
   {
-    ps_.reset(
+    if (server_->hasParam("RobotDescription")) {
+      EParam<std_msgs::String> robot_description_param;
+      server_->getParam("RobotDescription", robot_description_param);
+      ROS_INFO_STREAM("Loading collision scene for robot_description at " << robot_description_param->data);
+      ps_.reset(
+        new planning_scene::PlanningScene(
+            server_->getModel(robot_description_param->data)));
+    } else {
+      ps_.reset(
         new planning_scene::PlanningScene(
             server_->getModel("robot_description")));
+    }
+
     if (!acm_)
     {
       acm_.reset(
@@ -625,15 +635,22 @@ namespace exotica
     server_ = server;
     if (!handle.FirstChildElement("Kinematica").ToElement())
     {
-      throw_named("Kinametica not found!");
+      throw_named("Kinematica not found!");
     }
 
-    server->getModel("robot_description", model_);
+    if (server_->hasParam("RobotDescription")) {
+      EParam<std_msgs::String> robot_description_param;
+      server_->getParam("RobotDescription", robot_description_param);
+      ROS_INFO_STREAM("Using robot_description at " << robot_description_param->data);
+      server->getModel(robot_description_param->data, model_);
+    } else {
+      server->getModel("robot_description", model_);
+    }
 
     tinyxml2::XMLHandle tmp_handle(handle.FirstChildElement("Kinematica"));
     if (!kinematica_.initKinematics(tmp_handle, model_))
     {
-      throw_named("Kinametica not initialized!");
+      throw_named("Kinematica not initialized!");
     }
     std::string base_type = kinematica_.getBaseType();
     if (base_type.compare("fixed") == 0)

--- a/exotica/src/Server.cpp
+++ b/exotica/src/Server.cpp
@@ -169,7 +169,7 @@ namespace exotica
           tmp_handle.FirstChildElement("default").ToElement()->GetText();
       if (str.size() == 0)
       {
-        throw_pretty("Invalid srtring!");
+        throw_pretty("Invalid string!");
       }
       std_msgs::String ros_s;
       ros_s.data =

--- a/exotica/src/Server.cpp
+++ b/exotica/src/Server.cpp
@@ -62,7 +62,7 @@ namespace exotica
       }
       else
       {
-        throw_pretty("Couldn't load the model!");
+        throw_pretty("Couldn't load the model at path " << path << "!");
       }
     }
   }


### PR DESCRIPTION
The parameter to use instead of the default robot_description ROS param can be set as a string EXOTica-Server parameter named ``<RobotDescription>``.

Addresses and resolves issue #41.

@VladimirIvan is this okay?