### PR TITLE
Initializer fix and Compatibility with Ubuntu Xenial 16.04 LTS and Kinetic Kame

### DIFF
--- a/examples/exotica_examples/CMakeLists.txt
+++ b/examples/exotica_examples/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 catkin_package(
-
 )
 
 include_directories(
@@ -18,7 +17,6 @@ include_directories(
 )
 
 add_executable(ExoticaCore src/core.cpp)
-
 target_link_libraries(ExoticaCore
   ${catkin_LIBRARIES}
 )

--- a/examples/exotica_examples/package.xml
+++ b/examples/exotica_examples/package.xml
@@ -8,7 +8,7 @@
 
   <license>BSD</license>
 
-  <url type="website">https://bitbucket.org/IPAB-SLMC/exotica</url>
+  <url type="website">https://github.com/openhumanoids/exotica</url>
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>exotica</depend>

--- a/exotations/solvers/aico/CMakeLists.txt
+++ b/exotations/solvers/aico/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(Boost REQUIRED COMPONENTS signals)
 find_package(LAPACK REQUIRED)
 
 catkin_package(
-  INCLUDE_DIRS include
+  INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/include
   LIBRARIES aico
   CATKIN_DEPENDS exotica
 )

--- a/exotations/solvers/aico/CMakeLists.txt
+++ b/exotations/solvers/aico/CMakeLists.txt
@@ -7,7 +7,6 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 ## System dependencies are found with CMake's conventions
-find_package(Boost REQUIRED COMPONENTS signals)
 find_package(LAPACK REQUIRED)
 
 AddInitializer(AICOsolver)
@@ -33,9 +32,8 @@ add_library(aico
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(aico
-  ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${LAPACK_LIBRARIES}
+  ${catkin_LIBRARIES} ${LAPACK_LIBRARIES}
 )
-
 add_dependencies(aico aico_initializers)
 
 ## Install

--- a/exotations/solvers/aico/CMakeLists.txt
+++ b/exotations/solvers/aico/CMakeLists.txt
@@ -14,7 +14,6 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES aico
   CATKIN_DEPENDS exotica
-  DEPENDS system_lib
 )
 
 AddInitializer(AICOsolver)

--- a/exotations/solvers/aico/CMakeLists.txt
+++ b/exotations/solvers/aico/CMakeLists.txt
@@ -10,14 +10,14 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(Boost REQUIRED COMPONENTS signals)
 find_package(LAPACK REQUIRED)
 
+AddInitializer(AICOsolver)
+GenInitializers()
+
 catkin_package(
-  INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/include
+  INCLUDE_DIRS include
   LIBRARIES aico
   CATKIN_DEPENDS exotica
 )
-
-AddInitializer(AICOsolver)
-GenInitializers()
 
 include_directories(
   include

--- a/exotations/solvers/ik_solver/CMakeLists.txt
+++ b/exotations/solvers/ik_solver/CMakeLists.txt
@@ -14,7 +14,6 @@ catkin_package(
 INCLUDE_DIRS include
 LIBRARIES ik_solver
 CATKIN_DEPENDS exotica
-DEPENDS system_lib
 )
 
 AddInitializer(IKsolver)

--- a/exotations/solvers/ik_solver/CMakeLists.txt
+++ b/exotations/solvers/ik_solver/CMakeLists.txt
@@ -5,9 +5,6 @@ find_package(catkin REQUIRED COMPONENTS
   exotica
 )
 
-
-find_package(Boost REQUIRED COMPONENTS signals)
-
 find_package(LAPACK REQUIRED)
 
 AddInitializer(IKsolver)
@@ -27,11 +24,9 @@ include_directories(
 add_library(ik_solver
   src/ik_solver/IKSolver.cpp
 )
-
 target_link_libraries(ik_solver
-  ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${LAPACK_LIBRARIES}
+  ${catkin_LIBRARIES} ${LAPACK_LIBRARIES}
 )
-
 add_dependencies(ik_solver ik_solver_initializers)
 
 install(TARGETS ik_solver

--- a/exotations/solvers/ik_solver/CMakeLists.txt
+++ b/exotations/solvers/ik_solver/CMakeLists.txt
@@ -11,9 +11,9 @@ find_package(Boost REQUIRED COMPONENTS signals)
 find_package(LAPACK REQUIRED)
 
 catkin_package(
-INCLUDE_DIRS include
-LIBRARIES ik_solver
-CATKIN_DEPENDS exotica
+	INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/include
+	LIBRARIES ik_solver
+	CATKIN_DEPENDS exotica
 )
 
 AddInitializer(IKsolver)

--- a/exotations/solvers/ik_solver/CMakeLists.txt
+++ b/exotations/solvers/ik_solver/CMakeLists.txt
@@ -10,15 +10,14 @@ find_package(Boost REQUIRED COMPONENTS signals)
 
 find_package(LAPACK REQUIRED)
 
+AddInitializer(IKsolver)
+GenInitializers()
+
 catkin_package(
-	INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/include
+	INCLUDE_DIRS include
 	LIBRARIES ik_solver
 	CATKIN_DEPENDS exotica
 )
-
-AddInitializer(IKsolver)
-
-GenInitializers()
 
 include_directories(
   include
@@ -38,4 +37,5 @@ add_dependencies(ik_solver ik_solver_initializers)
 install(TARGETS ik_solver
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/ DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})

--- a/exotations/solvers/ompl_imp_solver/CMakeLists.txt
+++ b/exotations/solvers/ompl_imp_solver/CMakeLists.txt
@@ -26,7 +26,6 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ompl_imp_solver
   CATKIN_DEPENDS exotica ompl_solver pluginlib
-  DEPENDS system_lib
 )
 
 AddInitializer(OMPLImplementation)

--- a/exotations/solvers/ompl_imp_solver/CMakeLists.txt
+++ b/exotations/solvers/ompl_imp_solver/CMakeLists.txt
@@ -9,6 +9,18 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(Boost REQUIRED COMPONENTS system)
 
+# Check ROS version
+execute_process(
+  COMMAND rosversion -d
+  OUTPUT_VARIABLE ROS_VERSION
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if (${ROS_VERSION} MATCHES "(indigo|jade)")
+  add_definitions(-DROS_INDIGO)
+else (${ROS_VERSION} MATCHES "(kinetic|lunar")
+  add_definitions(-DROS_KINETIC)
+endif()
 
 catkin_package(
   INCLUDE_DIRS include

--- a/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLBaseStateSpace.cpp
+++ b/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLBaseStateSpace.cpp
@@ -77,8 +77,13 @@ namespace exotica
       double &dist) const
   {
     Eigen::VectorXd q(prob_->getSpaceDim());
+#ifdef ROS_INDIGO
     boost::static_pointer_cast<OMPLBaseStateSpace>(si_->getStateSpace())->OMPLToExoticaState(
         state, q);
+#elif ROS_KINETIC
+    std::static_pointer_cast<OMPLBaseStateSpace>(si_->getStateSpace())->OMPLToExoticaState(
+        state, q);
+#endif
     boost::mutex::scoped_lock lock(prob_->getLock());
     prob_->update(q, 0);
     if (!prob_->getScene()->getCollisionScene()->isStateValid(self_collision_->data, margin_->data))

--- a/exotations/solvers/ompl_solver/CMakeLists.txt
+++ b/exotations/solvers/ompl_solver/CMakeLists.txt
@@ -14,8 +14,7 @@ find_package(Boost REQUIRED COMPONENTS system)
 catkin_package(
   INCLUDE_DIRS include 
   LIBRARIES ompl_base_solver
-  CATKIN_DEPENDS exotica pluginlib
-  DEPENDS system_lib ompl
+  CATKIN_DEPENDS exotica pluginlib ompl
 )
 
 AddInitializer(OMPLsolver)

--- a/exotations/solvers/ompl_solver/include/ompl_solver/OMPLBaseSolver.h
+++ b/exotations/solvers/ompl_solver/include/ompl_solver/OMPLBaseSolver.h
@@ -137,7 +137,7 @@ namespace exotica
       boost::shared_ptr<og::SimpleSetup> ompl_simple_setup_;
 
       /// \brief OMPL state space specification
-      boost::shared_ptr<ob::StateSpace> state_space_;
+      ompl::base::StateSpacePtr state_space_;
 
       /// \brief Maximum allowed time for planning
       double timeout_;

--- a/exotations/task_maps/dmesh_ros/CMakeLists.txt
+++ b/exotations/task_maps/dmesh_ros/CMakeLists.txt
@@ -10,15 +10,14 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(Boost REQUIRED COMPONENTS system)
 
+AddInitializer(DMeshROS)
+GenInitializers()
 
 catkin_package(
-  INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/include
+  INCLUDE_DIRS include
   LIBRARIES dmesh_ros
   CATKIN_DEPENDS exotica roscpp ik_solver visualization_msgs
 )
-
-AddInitializer(DMeshROS)
-GenInitializers()
 
 include_directories(
   include
@@ -32,7 +31,6 @@ add_library(${PROJECT_NAME}
   src/MeshGraph.cpp
 )
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
-
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_initializers)
 
 ## Install

--- a/exotations/task_maps/dmesh_ros/CMakeLists.txt
+++ b/exotations/task_maps/dmesh_ros/CMakeLists.txt
@@ -15,7 +15,6 @@ catkin_package(
   INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/include
   LIBRARIES dmesh_ros
   CATKIN_DEPENDS exotica roscpp ik_solver visualization_msgs
-  DEPENDS system_lib
 )
 
 AddInitializer(DMeshROS)

--- a/exotations/task_maps/dmesh_ros/CMakeLists.txt
+++ b/exotations/task_maps/dmesh_ros/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(Boost REQUIRED COMPONENTS system)
 
 
 catkin_package(
-  INCLUDE_DIRS include
+  INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/include
   LIBRARIES dmesh_ros
   CATKIN_DEPENDS exotica roscpp ik_solver visualization_msgs
   DEPENDS system_lib

--- a/exotations/task_maps/task_map/CMakeLists.txt
+++ b/exotations/task_maps/task_map/CMakeLists.txt
@@ -12,7 +12,6 @@ catkin_package(
   INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/include
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS exotica geometry_msgs
-  DEPENDS #system_lib
 )
 
 AddInitializer(CoM IMesh EffPosition JointLimit SweepFlux Distance Identity SphereCollision Sphere)

--- a/exotations/task_maps/task_map/CMakeLists.txt
+++ b/exotations/task_maps/task_map/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 catkin_package(
-  INCLUDE_DIRS include
+  INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/include
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS exotica geometry_msgs
   DEPENDS #system_lib

--- a/exotations/task_maps/task_map/CMakeLists.txt
+++ b/exotations/task_maps/task_map/CMakeLists.txt
@@ -8,14 +8,24 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
 )
 
+AddInitializer(
+  CoM
+  IMesh
+  EffPosition
+  JointLimit
+  SweepFlux
+  Distance
+  Identity
+  SphereCollision
+  Sphere
+)
+GenInitializers()
+
 catkin_package(
-  INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/include
+  INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS exotica geometry_msgs
 )
-
-AddInitializer(CoM IMesh EffPosition JointLimit SweepFlux Distance Identity SphereCollision Sphere)
-GenInitializers()
 
 include_directories(
   include

--- a/exotica/cmake/AddInitializer.cmake
+++ b/exotica/cmake/AddInitializer.cmake
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
+find_package(PythonInterp REQUIRED)
+
 set(_InitializerInputFiles)
 set(_InitializerOutputFiles)
 set(_InitializerCopyFiles)
@@ -22,7 +24,7 @@ macro(GenInitializers)
 include_directories(${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 add_custom_command(
   OUTPUT ${_InitializerOutputFiles}
-  COMMAND python ${_InitializerScriptDir}/GenerateInitializers.py exotica "${_InitializerSearchPaths}" ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION} ${_InitializerInputFiles} ${_InitializerOutputFiles}
+  COMMAND ${PYTHON_EXECUTABLE} ${_InitializerScriptDir}/GenerateInitializers.py exotica "${_InitializerSearchPaths}" ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION} ${_InitializerInputFiles} ${_InitializerOutputFiles}
   DEPENDS ${_InitializerInputFiles} ${_InitializerScriptDir}/GenerateInitializers.py
 )
 add_custom_target(${PROJECT_NAME}_initializers DEPENDS ${_InitializerOutputFiles})

--- a/exotica/cmake/AddInitializer.cmake
+++ b/exotica/cmake/AddInitializer.cmake
@@ -12,6 +12,9 @@ foreach(path ${CMAKE_PREFIX_PATH})
 endforeach()
 
 macro(AddInitializer)
+  catkin_destinations()
+  file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+
   foreach(arg ${ARGN})
     list(APPEND _InitializerInputFiles ${CMAKE_CURRENT_SOURCE_DIR}/init/${arg}.in)
     list(APPEND _InitializerOutputFiles ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}/${arg}Initializer.h)
@@ -33,4 +36,17 @@ macro(GenInitializers)
     DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
   install(FILES ${_InitializerInputFiles}
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/init)
+
+  GenInitializers_append_include_dirs()
 endmacro(GenInitializers)
+
+# akin to https://github.com/ros/gencpp/blob/indigo-devel/cmake/gencpp-extras.cmake.em#L54
+macro(GenInitializers_append_include_dirs)
+  if(NOT GenInitializers_APPENDED_INCLUDE_DIRS)
+    # make sure we can find generated messages and that they overlay all other includes
+    include_directories(BEFORE ${CATKIN_DEVEL_PREFIX}/include)
+    # pass the include directory to catkin_package()
+    list(APPEND ${PROJECT_NAME}_INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include)
+    set(GenInitializers_APPENDED_INCLUDE_DIRS TRUE)
+  endif()
+endmacro()

--- a/exotica/cmake/AddInitializer.cmake
+++ b/exotica/cmake/AddInitializer.cmake
@@ -21,19 +21,16 @@ macro(AddInitializer)
 endmacro(AddInitializer)
 
 macro(GenInitializers)
-include_directories(${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION})
-add_custom_command(
-  OUTPUT ${_InitializerOutputFiles}
-  COMMAND ${PYTHON_EXECUTABLE} ${_InitializerScriptDir}/GenerateInitializers.py exotica "${_InitializerSearchPaths}" ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION} ${_InitializerInputFiles} ${_InitializerOutputFiles}
-  DEPENDS ${_InitializerInputFiles} ${_InitializerScriptDir}/GenerateInitializers.py
-)
-add_custom_target(${PROJECT_NAME}_initializers DEPENDS ${_InitializerOutputFiles})
+  include_directories(${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+  add_custom_command(
+    OUTPUT ${_InitializerOutputFiles}
+    COMMAND ${PYTHON_EXECUTABLE} ${_InitializerScriptDir}/GenerateInitializers.py exotica "${_InitializerSearchPaths}" ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION} ${_InitializerInputFiles} ${_InitializerOutputFiles}
+    DEPENDS ${_InitializerInputFiles} ${_InitializerScriptDir}/GenerateInitializers.py
+  )
+  add_custom_target(${PROJECT_NAME}_initializers DEPENDS ${_InitializerOutputFiles})
 
-install(FILES ${_InitializerOutputFiles}
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
-install(FILES ${_InitializerInputFiles}
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/init)
-
+  install(FILES ${_InitializerOutputFiles}
+    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+  install(FILES ${_InitializerInputFiles}
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/init)
 endmacro(GenInitializers)
-
-


### PR DESCRIPTION
This PR brings in a range of updates:

1. It fixes the initializers for non-install spaces and thereby properly resolves #57 
2. It removes some non-required dependencies that were spewing warnings
3. It makes Exotica compatible with 16.04 and Kinetic Kame.

Fully tested with both ``catkin_make_isolated`` and ``catkin build`` on Xenial + Kinetic. Travis confirmed that all changes work with Trusty + Indigo.