### PR TITLE
Lie group algebra and new task maps

### DIFF
--- a/examples/exotica_examples/resources/aico_solver_demo.xml
+++ b/examples/exotica_examples/resources/aico_solver_demo.xml
@@ -20,19 +20,20 @@
     </PlanningScene>
 
     <Maps>
-      <EffPosition Name="Position">
-        <Scene>AICOSolverDemoScene</Scene>
+      <EffFrame Name="Frame">
+        <Scene>MyScene</Scene>
+        <Type>RPY</Type>
         <EndEffector>
-          <Frame Link="lwr_arm_6_link" />
+            <Frame Link="lwr_arm_6_link" LinkOffset="0 0 0 0.7071067811865476 -4.3297802811774664e-17  0.7071067811865475 4.3297802811774664e-17" BaseOffset="0.4 -0.1 0.5 0 0 0 1" />
         </EndEffector>
-      </EffPosition>
+      </EffFrame>
     </Maps>
    
     <T>100</T>
     <Tau>0.05</Tau>
     <Qrate>1e-10</Qrate>
-    <Hrate>1.0</Hrate>
-    <Wrate>1.0</Wrate>
+    <Hrate>1</Hrate>
+    <Wrate>1</Wrate>
     <W> 7 6 5 4 3 2 1 </W>
   </UnconstrainedTimeIndexedProblem>
 

--- a/examples/exotica_examples/resources/ompl_solver_demo.xml
+++ b/examples/exotica_examples/resources/ompl_solver_demo.xml
@@ -15,7 +15,7 @@
       </Scene>
     </PlanningScene>
 
-    <Goal>-0.134914 -0.229508 -0.124971 1.94267 -1.4921e-17 0.0 0.0</Goal>
+    <Goal>2.16939  0.313509   -2.2954   1.94413 -0.276843  0.567194         0</Goal>
   </SamplingProblem>
 
 </PlannerDemoConfig>

--- a/examples/exotica_examples/resources/rviz.rviz
+++ b/examples/exotica_examples/resources/rviz.rviz
@@ -7,9 +7,8 @@ Panels:
         - /Global Options1
         - /Status1
         - /RobotModel1
-        - /PoseArray1
-        - /Marker1
-        - /Marker1/Namespaces1
+        - /TF1
+        - /TF1/Tree1/exotica/world_frame1
       Splitter Ratio: 0.589404
     Tree Height: 1751
   - Class: rviz/Selection
@@ -113,21 +112,64 @@ Visualization Manager:
       Update Interval: 0
       Value: true
       Visual Enabled: true
-    - Arrow Length: 0.1
-      Class: rviz/PoseArray
-      Color: 255; 25; 0
+    - Class: rviz/TF
       Enabled: true
-      Name: PoseArray
-      Topic: /xsens_debug
-      Unreliable: false
-      Value: true
-    - Class: rviz/Marker
-      Enabled: true
-      Marker Topic: /InteractionMesh
-      Name: Marker
-      Namespaces:
-        {}
-      Queue Size: 10
+      Frame Timeout: 15
+      Frames:
+        All Enabled: false
+        exotica/Frame0Alwr_arm_6_link:
+          Value: true
+        exotica/Frame0Bworld_frame:
+          Value: true
+        exotica/base:
+          Value: false
+        exotica/lwr_arm_0_link:
+          Value: false
+        exotica/lwr_arm_1_link:
+          Value: false
+        exotica/lwr_arm_2_link:
+          Value: false
+        exotica/lwr_arm_3_link:
+          Value: false
+        exotica/lwr_arm_4_link:
+          Value: false
+        exotica/lwr_arm_5_link:
+          Value: false
+        exotica/lwr_arm_6_link:
+          Value: false
+        exotica/lwr_arm_7_link:
+          Value: false
+        exotica/world_frame:
+          Value: false
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        exotica/world_frame:
+          exotica/Frame0Bworld_frame:
+            exotica/Frame0Alwr_arm_6_link:
+              {}
+          exotica/base:
+            {}
+          exotica/lwr_arm_0_link:
+            {}
+          exotica/lwr_arm_1_link:
+            {}
+          exotica/lwr_arm_2_link:
+            {}
+          exotica/lwr_arm_3_link:
+            {}
+          exotica/lwr_arm_4_link:
+            {}
+          exotica/lwr_arm_5_link:
+            {}
+          exotica/lwr_arm_6_link:
+            {}
+          exotica/lwr_arm_7_link:
+            {}
+      Update Interval: 0
       Value: true
   Enabled: true
   Global Options:
@@ -153,22 +195,22 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/Orbit
-      Distance: 4.85509
+      Distance: 3.81298
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.06
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: 0.0761497
-        Y: 0.0373956
-        Z: 0.0101348
+        X: 0.0264329
+        Y: -0.0667396
+        Z: 0.139345
       Name: Current View
       Near Clip Distance: 0.01
-      Pitch: 0.494797
+      Pitch: 0.589797
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 0.0472035
+      Yaw: 0.517203
     Saved: ~
 Window Geometry:
   Displays:

--- a/examples/exotica_examples/src/generic.cpp
+++ b/examples/exotica_examples/src/generic.cpp
@@ -62,9 +62,9 @@ void run()
         // Update the goal if necessary
         // e.g. figure eight
         t = ros::Duration((ros::WallTime::now() - init_time).toSec()).toSec();
-        my_problem->y << 0.6,
+        my_problem->y = {0.6,
                 -0.1 + sin(t * 2.0 * M_PI * 0.5) * 0.1,
-                0.5 + sin(t * M_PI * 0.5) * 0.2;
+                0.5 + sin(t * M_PI * 0.5) * 0.2};
 
         // Solve the problem using the IK solver
         any_solver->Solve(q, solution);

--- a/examples/exotica_examples/src/manual.cpp
+++ b/examples/exotica_examples/src/manual.cpp
@@ -53,9 +53,9 @@ void run()
         // Update the goal if necessary
         // e.g. figure eight
         t = ros::Duration((ros::WallTime::now() - init_time).toSec()).toSec();
-        my_problem->y << 0.6,
+        my_problem->y = {0.6,
                 -0.1 + sin(t * 2.0 * M_PI * 0.5) * 0.1,
-                0.5 + sin(t * M_PI * 0.5) * 0.2;
+                0.5 + sin(t * M_PI * 0.5) * 0.2};
 
         // Solve the problem using the IK solver
         any_solver->Solve(q, solution);

--- a/examples/exotica_examples/src/xml.cpp
+++ b/examples/exotica_examples/src/xml.cpp
@@ -44,9 +44,9 @@ void run()
         // Update the goal if necessary
         // e.g. figure eight
         t = ros::Duration((ros::WallTime::now() - init_time).toSec()).toSec();
-        my_problem->y << 0.6,
+        my_problem->y = {0.6,
                 -0.1 + sin(t * 2.0 * M_PI * 0.5) * 0.1,
-                0.5 + sin(t * M_PI * 0.5) * 0.2;
+                0.5 + sin(t * M_PI * 0.5) * 0.2};
 
         // Solve the problem using the IK solver
         any_solver->Solve(q, solution);

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -263,7 +263,7 @@ namespace exotica
 
     costControl.resize(T);
     costControl.setZero();
-    costTask.resize(T, prob_->PhiN);
+    costTask.resize(T, prob_->JN);
     costTask.setZero();
 
     q_stat.resize(T);
@@ -485,25 +485,22 @@ namespace exotica
       rhat[t] = 0;
       R[t].setZero();
       r[t].setZero();
-      for (int i = 0; i < prob_->Mapping.rows(); i++)
+      for (int i = 0; i < prob_->getTasks().size(); i++)
       {
         prec = prob_->Rho[t](i);
         if (prec > 0)
         {
-            int start = prob_->Mapping(i,0);
-            int len = prob_->Mapping(i,1);
+            int start = prob_->getTasks()[i]->StartJ;
+            int len = prob_->getTasks()[i]->LengthJ;
           Jt = prob_->J[t].middleRows(start, len).transpose();
           C += prec
-              * (prob_->y[t].segment(start, len)
-                  - prob_->Phi[t].segment(start, len)).squaredNorm();
+              * (prob_->ydiff[t].segment(start, len)).squaredNorm();
           R[t] += prec * Jt * prob_->J[t].middleRows(start, len);
           r[t] += prec * Jt
-              * (prob_->y[t].segment(start, len)
-                  - prob_->Phi[t].segment(start, len)
+              * (prob_->ydiff[t].segment(start, len)
                   + prob_->J[t].middleRows(start, len) * qhat[t]);
           rhat[t] += prec
-              * (prob_->y[t].segment(start, len)
-                  - prob_->Phi[t].segment(start, len)
+              * (prob_->ydiff[t].segment(start, len)
                   + prob_->J[t].middleRows(start, len) * qhat[t]).squaredNorm();
         }
       }
@@ -516,25 +513,22 @@ namespace exotica
       rhat[t] = 0;
       R[t].setZero();
       r[t].setZero();
-      for (int i = 0; i < prob_->Mapping.rows(); i++)
+      for (int i = 0; i < prob_->getTasks().size(); i++)
       {
           prec = prob_->Rho[t](i);
           if (prec > 0)
           {
-                int start = prob_->Mapping(i,0);
-                int len = prob_->Mapping(i,1);
+              int start = prob_->getTasks()[i]->StartJ;
+              int len = prob_->getTasks()[i]->LengthJ;
                 Jt = prob_->J[t].middleRows(start, len).transpose();
                 C += prec
-                    * (prob_->y[t].segment(start, len)
-                        - prob_->Phi[t].segment(start, len)).squaredNorm();
+                    * (prob_->ydiff[t].segment(start, len)).squaredNorm();
                 R[t].topLeftCorner(n2, n2) += prec * Jt * prob_->J[t].middleRows(start, len);
                 r[t].head(n2) += prec * Jt
-                    * (prob_->y[t].segment(start, len)
-                        - prob_->Phi[t].segment(start, len)
+                    * (prob_->ydiff[t].segment(start, len)
                         + prob_->J[t].middleRows(start, len) * qhat[t]);
                 rhat[t] += prec
-                    * (prob_->y[t].segment(start, len)
-                        - prob_->Phi[t].segment(start, len)
+                    * (prob_->ydiff[t].segment(start, len)
                             + prob_->J[t].middleRows(start, len) * qhat[t]).squaredNorm();
           }
       }
@@ -674,17 +668,16 @@ namespace exotica
       dCtrl += ros::Time::now() - tmpTime;
       tmpTime = ros::Time::now();
       // Task cost
-      for (int i = 0; i < prob_->Mapping.rows(); i++)
+      for (int i = 0; i < prob_->getTasks().size(); i++)
       {
           // Position cost
           double prec = prob_->Rho[t](i);
           if (prec > 0)
           {
-                int start = prob_->Mapping(i,0);
-                int len = prob_->Mapping(i,1);
+              int start = prob_->getTasks()[i]->StartJ;
+              int len = prob_->getTasks()[i]->LengthJ;
                 costTask(t, i) = prec
-                    * (prob_->y[t].segment(start, len)
-                        - prob_->Phi[t].segment(start, len)).squaredNorm();
+                    * (prob_->ydiff[t].segment(start, len)).squaredNorm();
                 ret += costTask(t, i);
           }
       }

--- a/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
+++ b/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
@@ -104,9 +104,9 @@ namespace exotica
         MotionSolver::specifyProblem(pointer);
         prob_ = boost::static_pointer_cast<UnconstrainedEndPoseProblem>(pointer);
 
-        C = Eigen::MatrixXd::Identity(prob_->PhiN, prob_->PhiN)*parameters_.C;
+        C = Eigen::MatrixXd::Identity(prob_->JN, prob_->JN)*parameters_.C;
         if(parameters_.C==0.0)
-            Cinv = Eigen::MatrixXd::Zero(prob_->PhiN, prob_->PhiN);
+            Cinv = Eigen::MatrixXd::Zero(prob_->JN, prob_->JN);
         else
             Cinv = C.inverse();
 
@@ -138,8 +138,8 @@ namespace exotica
 
         bool UseNullspace = prob_->qNominal.rows()==prob_->N;
 
-        Eigen::MatrixXd S = Eigen::MatrixXd::Identity(prob_->PhiN, prob_->PhiN);
-        for(TaskMap_ptr task : prob_->Tasks)
+        Eigen::MatrixXd S = Eigen::MatrixXd::Identity(prob_->JN, prob_->JN);
+        for(TaskMap_ptr task : prob_->getTasks())
         {
             for(int i=0; i < task->Length; i++)
             {

--- a/exotations/task_maps/task_map/CMakeLists.txt
+++ b/exotations/task_maps/task_map/CMakeLists.txt
@@ -12,6 +12,8 @@ AddInitializer(
   CoM
   IMesh
   EffPosition
+  EffOrientation
+  EffFrame
   JointLimit
   Distance
   Identity
@@ -34,6 +36,8 @@ include_directories(
 add_library(${PROJECT_NAME} src/CoM.cpp
                             src/IMesh.cpp
                             src/EffPosition.cpp
+                            src/EffOrientation.cpp
+                            src/EffFrame.cpp
                             src/JointLimit.cpp
                             src/Distance.cpp
                             src/Identity.cpp

--- a/exotations/task_maps/task_map/exotica_plugins.xml
+++ b/exotations/task_maps/task_map/exotica_plugins.xml
@@ -8,6 +8,12 @@
   <class name="exotica/EffPosition" type="exotica::EffPosition" base_class_type="exotica::TaskMap">
     <description>End-effector position (3D)</description>
   </class>
+  <class name="exotica/EffOrientation" type="exotica::EffOrientation" base_class_type="exotica::TaskMap">
+    <description>End-effector position (SO3)</description>
+  </class>
+  <class name="exotica/EffFrame" type="exotica::EffFrame" base_class_type="exotica::TaskMap">
+    <description>End-effector frame (SE3)</description>
+  </class>
   <class name="exotica/SphereCollision" type="exotica::SphereCollision" base_class_type="exotica::TaskMap">
     <description>Sphere collision avoidance</description>
   </class>

--- a/exotations/task_maps/task_map/include/EffFrame.h
+++ b/exotations/task_maps/task_map/include/EffFrame.h
@@ -1,0 +1,71 @@
+/*
+ *      Author: Vladimir Ivan
+ * 
+ * Copyright (c) 2016, University Of Edinburgh 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met: 
+ * 
+ *  * Redistributions of source code must retain the above copyright notice, 
+ *    this list of conditions and the following disclaimer. 
+ *  * Redistributions in binary form must reproduce the above copyright 
+ *    notice, this list of conditions and the following disclaimer in the 
+ *    documentation and/or other materials provided with the distribution. 
+ *  * Neither the name of  nor the names of its contributors may be used to 
+ *    endorse or promote products derived from this software without specific 
+ *    prior written permission. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * POSSIBILITY OF SUCH DAMAGE. 
+ *
+ */
+
+#ifndef EXOTICA_TASKMAP_EFF_FRAME_H
+#define EXOTICA_TASKMAP_EFF_FRAME_H
+
+#include <exotica/TaskMap.h>
+#include <task_map/EffFrameInitializer.h>
+
+namespace exotica //!< Since this is part of the core library, it will be within the same namespace
+{
+  class EffFrame: public TaskMap, public Instantiable<EffFrameInitializer>
+  {
+    public:
+      /**
+       * \brief Default constructor
+       */
+      EffFrame();
+      virtual ~EffFrame()
+      {
+      }
+
+      virtual void Instantiate(EffFrameInitializer& init);
+
+      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+
+      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
+
+      virtual int taskSpaceDim();
+
+      virtual int taskSpaceJacobianDim();
+
+      virtual std::vector<TaskVectorEntry> getLieGroupIndices();
+
+      RotationType rotationType;
+      int bigStride;
+      int smallStride;
+  };
+  typedef boost::shared_ptr<EffFrame> EffFrame_ptr;  //!< Task Map smart pointer
+}
+
+#endif

--- a/exotations/task_maps/task_map/include/EffOrientation.h
+++ b/exotations/task_maps/task_map/include/EffOrientation.h
@@ -1,0 +1,70 @@
+/*
+ *      Author: Vladimir Ivan
+ * 
+ * Copyright (c) 2016, University Of Edinburgh 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met: 
+ * 
+ *  * Redistributions of source code must retain the above copyright notice, 
+ *    this list of conditions and the following disclaimer. 
+ *  * Redistributions in binary form must reproduce the above copyright 
+ *    notice, this list of conditions and the following disclaimer in the 
+ *    documentation and/or other materials provided with the distribution. 
+ *  * Neither the name of  nor the names of its contributors may be used to 
+ *    endorse or promote products derived from this software without specific 
+ *    prior written permission. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * POSSIBILITY OF SUCH DAMAGE. 
+ *
+ */
+
+#ifndef EXOTICA_TASKMAP_EFF_ORIENTATION_H
+#define EXOTICA_TASKMAP_EFF_ORIENTATION_H
+
+#include <exotica/TaskMap.h>
+#include <task_map/EffOrientationInitializer.h>
+
+namespace exotica //!< Since this is part of the core library, it will be within the same namespace
+{
+  class EffOrientation: public TaskMap, public Instantiable<EffOrientationInitializer>
+  {
+    public:
+      /**
+       * \brief Default constructor
+       */
+      EffOrientation();
+      virtual ~EffOrientation()
+      {
+      }
+
+      virtual void Instantiate(EffOrientationInitializer& init);
+
+      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi);
+
+      virtual void update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J);
+
+      virtual int taskSpaceDim();
+
+      virtual int taskSpaceJacobianDim();
+
+      virtual std::vector<TaskVectorEntry> getLieGroupIndices();
+
+      RotationType rotationType;
+      int stride;
+  };
+  typedef boost::shared_ptr<EffOrientation> EffOrientation_ptr;  //!< Task Map smart pointer
+}
+
+#endif

--- a/exotations/task_maps/task_map/init/EffFrame.in
+++ b/exotations/task_maps/task_map/init/EffFrame.in
@@ -1,0 +1,2 @@
+extend <exotica/TaskMap>
+Optional std::string Type = "RPY";

--- a/exotations/task_maps/task_map/init/EffOrientation.in
+++ b/exotations/task_maps/task_map/init/EffOrientation.in
@@ -1,0 +1,2 @@
+extend <exotica/TaskMap>
+Optional std::string Type = "RPY";

--- a/exotations/task_maps/task_map/src/EffFrame.cpp
+++ b/exotations/task_maps/task_map/src/EffFrame.cpp
@@ -71,7 +71,7 @@ namespace exotica
         std::vector<TaskVectorEntry> ret;
         for(int i=0;i<Kinematics.Phi.rows();i++)
         {
-            ret.push_back(TaskVectorEntry(Start + i*bigStride + 3, StartJ + i*3 + 3, rotationType));
+            ret.push_back(TaskVectorEntry(Start + i*bigStride + 3, rotationType));
         }
         return ret;
     }

--- a/exotations/task_maps/task_map/src/EffFrame.cpp
+++ b/exotations/task_maps/task_map/src/EffFrame.cpp
@@ -1,0 +1,114 @@
+/*
+ *      Author: Vladimir Ivan
+ * 
+ * Copyright (c) 2016, University Of Edinburgh 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met: 
+ * 
+ *  * Redistributions of source code must retain the above copyright notice, 
+ *    this list of conditions and the following disclaimer. 
+ *  * Redistributions in binary form must reproduce the above copyright 
+ *    notice, this list of conditions and the following disclaimer in the 
+ *    documentation and/or other materials provided with the distribution. 
+ *  * Neither the name of  nor the names of its contributors may be used to 
+ *    endorse or promote products derived from this software without specific 
+ *    prior written permission. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * POSSIBILITY OF SUCH DAMAGE. 
+ *
+ */
+
+#include "EffFrame.h"
+
+REGISTER_TASKMAP_TYPE("EffFrame", exotica::EffFrame);
+
+namespace exotica
+{
+    EffFrame::EffFrame() : rotationType(RotationType::RPY)
+    {
+    }
+
+    void EffFrame::Instantiate(EffFrameInitializer& init)
+    {
+        if(init.Type == "Quaternion")
+        {
+            rotationType = RotationType::QUATERNION;
+        }
+        else if(init.Type == "ZYX")
+        {
+            rotationType = RotationType::ZYX;
+        }
+        else if(init.Type == "ZYZ")
+        {
+            rotationType = RotationType::ZYZ;
+        }
+        else if(init.Type == "AngleAxis")
+        {
+            rotationType = RotationType::ANGLE_AXIS;
+        }
+        else if(init.Type == "Matrix")
+        {
+            rotationType = RotationType::MATRIX;
+        }
+        smallStride = getRotationTypeLength(rotationType);
+        bigStride = smallStride + 3;
+    }
+
+    std::vector<TaskVectorEntry> EffFrame::getLieGroupIndices()
+    {
+        std::vector<TaskVectorEntry> ret;
+        for(int i=0;i<Kinematics.Phi.rows();i++)
+        {
+            ret.push_back(TaskVectorEntry(Start + i*bigStride + 3, StartJ + i*3 + 3, rotationType));
+        }
+        return ret;
+    }
+
+    void EffFrame::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+    {
+        if(phi.rows() != Kinematics.Phi.rows()*bigStride) throw_named("Wrong size of phi!");
+        for(int i=0;i<Kinematics.Phi.rows();i++)
+        {
+            phi(i*bigStride) = Kinematics.Phi(i).p[0];
+            phi(i*bigStride+1) = Kinematics.Phi(i).p[1];
+            phi(i*bigStride+2) = Kinematics.Phi(i).p[2];
+            phi.segment(i*bigStride + 3, smallStride) = setRotation(Kinematics.Phi(i).M, rotationType);
+        }
+    }
+
+    void EffFrame::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
+    {
+        if(phi.rows() != Kinematics.Phi.rows()*bigStride) throw_named("Wrong size of phi!");
+        if(J.rows() != Kinematics.J.rows()*6 || J.cols() != Kinematics.J(0).data.cols()) throw_named("Wrong size of J! " << Kinematics.J(0).data.cols());
+        for(int i=0;i<Kinematics.Phi.rows();i++)
+        {
+            phi(i*bigStride) = Kinematics.Phi(i).p[0];
+            phi(i*bigStride+1) = Kinematics.Phi(i).p[1];
+            phi(i*bigStride+2) = Kinematics.Phi(i).p[2];
+            phi.segment(i*bigStride + 3, smallStride) = setRotation(Kinematics.Phi(i).M, rotationType);
+            J.middleRows(i*6,6) = Kinematics.J[i].data;
+        }
+    }
+
+    int EffFrame::taskSpaceDim()
+    {
+        return Kinematics.Phi.rows()*bigStride;
+    }
+
+    int EffFrame::taskSpaceJacobianDim()
+    {
+        return Kinematics.Phi.rows() * 6;
+    }
+}

--- a/exotations/task_maps/task_map/src/EffOrientation.cpp
+++ b/exotations/task_maps/task_map/src/EffOrientation.cpp
@@ -71,7 +71,7 @@ namespace exotica
         std::vector<TaskVectorEntry> ret;
         for(int i=0;i<Kinematics.Phi.rows();i++)
         {
-            ret.push_back(TaskVectorEntry(Start + i*stride, StartJ + i*3, rotationType));
+            ret.push_back(TaskVectorEntry(Start + i*stride, rotationType));
         }
         return ret;
     }

--- a/exotations/task_maps/task_map/src/EffOrientation.cpp
+++ b/exotations/task_maps/task_map/src/EffOrientation.cpp
@@ -1,0 +1,108 @@
+/*
+ *      Author: Vladimir Ivan
+ * 
+ * Copyright (c) 2016, University Of Edinburgh 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met: 
+ * 
+ *  * Redistributions of source code must retain the above copyright notice, 
+ *    this list of conditions and the following disclaimer. 
+ *  * Redistributions in binary form must reproduce the above copyright 
+ *    notice, this list of conditions and the following disclaimer in the 
+ *    documentation and/or other materials provided with the distribution. 
+ *  * Neither the name of  nor the names of its contributors may be used to 
+ *    endorse or promote products derived from this software without specific 
+ *    prior written permission. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * POSSIBILITY OF SUCH DAMAGE. 
+ *
+ */
+
+#include "EffOrientation.h"
+
+REGISTER_TASKMAP_TYPE("EffOrientation", exotica::EffOrientation);
+
+namespace exotica
+{
+
+    EffOrientation::EffOrientation() : rotationType(RotationType::RPY)
+    {
+    }
+
+    void EffOrientation::Instantiate(EffOrientationInitializer& init)
+    {
+        if(init.Type == "Quaternion")
+        {
+            rotationType = RotationType::QUATERNION;
+        }
+        else if(init.Type == "ZYX")
+        {
+            rotationType = RotationType::ZYX;
+        }
+        else if(init.Type == "ZYZ")
+        {
+            rotationType = RotationType::ZYZ;
+        }
+        else if(init.Type == "AngleAxis")
+        {
+            rotationType = RotationType::ANGLE_AXIS;
+        }
+        else if(init.Type == "Matrix")
+        {
+            rotationType = RotationType::MATRIX;
+        }
+        stride = getRotationTypeLength(rotationType);
+    }
+
+    std::vector<TaskVectorEntry> EffOrientation::getLieGroupIndices()
+    {
+        std::vector<TaskVectorEntry> ret;
+        for(int i=0;i<Kinematics.Phi.rows();i++)
+        {
+            ret.push_back(TaskVectorEntry(Start + i*stride, StartJ + i*3, rotationType));
+        }
+        return ret;
+    }
+
+    void EffOrientation::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi)
+    {
+        if(phi.rows() != Kinematics.Phi.rows()*stride) throw_named("Wrong size of phi!");
+        for(int i=0;i<Kinematics.Phi.rows();i++)
+        {
+            phi.segment(i*stride, stride) = setRotation(Kinematics.Phi(i).M, rotationType);
+        }
+    }
+
+    void EffOrientation::update(Eigen::VectorXdRefConst x, Eigen::VectorXdRef phi, Eigen::MatrixXdRef J)
+    {
+        if(phi.rows() != Kinematics.Phi.rows()*stride) throw_named("Wrong size of phi!");
+        if(J.rows() != Kinematics.J.rows()*3 || J.cols() != Kinematics.J(0).data.cols()) throw_named("Wrong size of J! " << Kinematics.J(0).data.cols());
+        for(int i=0;i<Kinematics.Phi.rows();i++)
+        {
+            phi.segment(i*stride, stride) = setRotation(Kinematics.Phi(i).M, rotationType);
+            J.middleRows(i*3,3) = Kinematics.J[i].data.bottomRows(3);
+        }
+    }
+
+    int EffOrientation::taskSpaceDim()
+    {
+        return Kinematics.Phi.rows()*stride;
+    }
+
+    int EffOrientation::taskSpaceJacobianDim()
+    {
+        return Kinematics.Phi.rows() * 3;
+    }
+}

--- a/exotations/task_maps/task_map/tests/test_maps.cpp
+++ b/exotations/task_maps/task_map/tests/test_maps.cpp
@@ -169,15 +169,22 @@ void testEffOrientation()
 void testEffFrame()
 {
     HIGHLIGHT("End-effector frame test");
-    Initializer map("exotica/EffFrame",{
-                        {"Name",std::string("Frame")},
-                        {"EndEffector",std::vector<Initializer>({
-                             Initializer("Frame",{{"Link",std::string("endeff")}})
-                                        }) } });
-    UnconstrainedEndPoseProblem_ptr problem = setupProbelm(map);
-    testRandom(problem);
+    std::vector<std::string> types = {"Quaternion", "ZYX", "ZYZ", "AngleAxis", "Matrix", "RPY"};
 
-    testJacobian(problem);
+    for(std::string type : types)
+    {
+        INFO_PLAIN("Rotation type "<<type);
+        Initializer map("exotica/EffFrame",{
+                            {"Name",std::string("Frame")},
+                            {"Type",type},
+                            {"EndEffector",std::vector<Initializer>({
+                                 Initializer("Frame",{{"Link",std::string("endeff")}})
+                                            }) } });
+        UnconstrainedEndPoseProblem_ptr problem = setupProbelm(map);
+        testRandom(problem);
+
+        testJacobian(problem);
+    }
 }
 
 void testDistance()

--- a/exotations/task_maps/task_map/tests/test_maps.cpp
+++ b/exotations/task_maps/task_map/tests/test_maps.cpp
@@ -80,7 +80,6 @@ void testJacobian(UnconstrainedEndPoseProblem_ptr problem, double eps = 1e-5)
         double errJ = (J-J0).norm();
         if(errJ > eps)
         {
-            HIGHLIGHT("map: "<<y0.map.size());
             HIGHLIGHT("x: "<<x0.transpose());
             HIGHLIGHT("J*:\n"<<J);
             HIGHLIGHT("J:\n"<<J0);

--- a/exotica/CMakeLists.txt
+++ b/exotica/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(${PROJECT_NAME}
   src/Scene.cpp
   src/Property.cpp
   src/KinematicTree.cpp
+  src/TaskSpaceVector.cpp
   src/Tools/Exception.cpp
   src/Tools/Printable.cpp
   src/Tools/Conversions.cpp

--- a/exotica/include/exotica/PlanningProblem.h
+++ b/exotica/include/exotica/PlanningProblem.h
@@ -33,12 +33,13 @@
 #ifndef EXOTICA_MOTION_PLANNING_PROBLEM_H
 #define EXOTICA_MOTION_PLANNING_PROBLEM_H
 
-#include "exotica/Object.h"
-#include "exotica/TaskMap.h"
-#include "exotica/Server.h"
-#include "exotica/Scene.h"
-#include "exotica/Tools.h"
-#include "exotica/Problem.h"
+#include <exotica/Object.h>
+#include <exotica/TaskMap.h>
+#include <exotica/Server.h>
+#include <exotica/Scene.h>
+#include <exotica/Tools.h>
+#include <exotica/Problem.h>
+#include <exotica/TaskSpaceVector.h>
 
 #include <vector>
 #include <string>
@@ -55,12 +56,14 @@ namespace exotica
         virtual ~PlanningProblem() {}
         virtual void InstantiateBase(const Initializer& init);
         TaskMap_map& getTaskMaps();
+        TaskMap_vec& getTasks();
         Scene_ptr getScene();
         virtual std::string print(std::string prepend);
 
     protected:
         Scene_ptr scene_;
         TaskMap_map TaskMaps;
+        TaskMap_vec Tasks;
         KinematicRequestFlags Flags;
 
     };

--- a/exotica/include/exotica/Problems/UnconstrainedEndPoseProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedEndPoseProblem.h
@@ -56,15 +56,14 @@ namespace exotica
         double getRho(const std::string & task_name);
 
         Eigen::VectorXd Rho;
-        Eigen::VectorXd y;
+        TaskSpaceVector y;
         Eigen::MatrixXd W;
-        Eigen::VectorXd Phi;
+        TaskSpaceVector Phi;
         Eigen::MatrixXd J;
         Eigen::VectorXd qNominal;
 
-        TaskMap_vec Tasks;
-        Eigen::MatrixXi Mapping;
         int PhiN;
+        int JN;
         int N;
         int NumTasks;
 

--- a/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedTimeIndexedProblem.h
@@ -70,13 +70,13 @@ namespace exotica
       Eigen::MatrixXd Q;
 
       std::vector<Eigen::VectorXd> Rho;
-      std::vector<Eigen::VectorXd> y;
-      std::vector<Eigen::VectorXd> Phi;
+      std::vector<TaskSpaceVector> y;
+      std::vector<TaskSpaceVector> Phi;
+      std::vector<Eigen::VectorXd> ydiff;
       std::vector<Eigen::MatrixXd> J;
 
-      TaskMap_vec Tasks;
-      Eigen::MatrixXi Mapping;
       int PhiN;
+      int JN;
       int N;
       int NumTasks;
 

--- a/exotica/include/exotica/TaskMap.h
+++ b/exotica/include/exotica/TaskMap.h
@@ -33,11 +33,12 @@
 #ifndef EXOTICA_TASK_MAP_H
 #define EXOTICA_TASK_MAP_H
 
-#include "exotica/Object.h"       //!< The EXOTica base class
-#include "exotica/Factory.h"      //!< The Factory template
-#include "exotica/Server.h"
-#include "exotica/Scene.h"
-#include "exotica/Property.h"
+#include <exotica/Object.h>       //!< The EXOTica base class
+#include <exotica/Factory.h>      //!< The Factory template
+#include <exotica/Server.h>
+#include <exotica/Scene.h>
+#include <exotica/Property.h>
+#include <exotica/TaskSpaceVector.h>
 
 #include <Eigen/Dense>            //!< Generally dense manipulations should be enough
 #include <boost/thread/mutex.hpp> //!< The boost thread-library for synchronisation
@@ -73,6 +74,10 @@ namespace exotica
 
       virtual int taskSpaceDim() = 0;
 
+      virtual int taskSpaceJacobianDim() { return taskSpaceDim();}
+
+      virtual std::vector<TaskVectorEntry> getLieGroupIndices() {return std::vector<TaskVectorEntry>();}
+
       void taskSpaceDim(int & task_dim);
 
       virtual std::string print(std::string prepend);
@@ -84,6 +89,8 @@ namespace exotica
       int Id;
       int Start;
       int Length;
+      int StartJ;
+      int LengthJ;
     protected:
 
       std::vector<KinematicFrameRequest> Frames;

--- a/exotica/include/exotica/TaskSpaceVector.h
+++ b/exotica/include/exotica/TaskSpaceVector.h
@@ -13,10 +13,9 @@ struct TaskVectorEntry
 {
     RotationType type;
     int inId;
-    int outId;
 
     TaskVectorEntry();
-    TaskVectorEntry(int inId_, int outId_, RotationType type_);
+    TaskVectorEntry(int inId_, RotationType type_);
 };
 
 class TaskSpaceVector
@@ -26,6 +25,7 @@ public:
     TaskSpaceVector();
     TaskSpaceVector& operator=(std::initializer_list<double> other);
     Eigen::VectorXd operator-(const TaskSpaceVector& other);
+    void setZero(int N);
 
     Eigen::VectorXd data;
     std::vector<TaskVectorEntry> map;

--- a/exotica/include/exotica/TaskSpaceVector.h
+++ b/exotica/include/exotica/TaskSpaceVector.h
@@ -1,0 +1,37 @@
+#ifndef TASKSPACEVECTOR_H
+#define TASKSPACEVECTOR_H
+
+#include <Eigen/Dense>
+#include <kdl/frames.hpp>
+#include <vector>
+#include <exotica/Tools.h>
+
+namespace exotica
+{
+
+struct TaskVectorEntry
+{
+    RotationType type;
+    int inId;
+    int outId;
+
+    TaskVectorEntry();
+    TaskVectorEntry(int inId_, int outId_, RotationType type_);
+};
+
+class TaskSpaceVector
+{
+public:
+
+    TaskSpaceVector();
+    TaskSpaceVector& operator=(std::initializer_list<double> other);
+    Eigen::VectorXd operator-(const TaskSpaceVector& other);
+
+    Eigen::VectorXd data;
+    std::vector<TaskVectorEntry> map;
+
+};
+
+}
+
+#endif // TASKSPACEVECTOR_H

--- a/exotica/include/exotica/Tools.h
+++ b/exotica/include/exotica/Tools.h
@@ -58,6 +58,26 @@
 namespace exotica
 {
 
+    enum RotationType
+    {
+        QUATERNION,
+        RPY,
+        ZYX,
+        ZYZ,
+        ANGLE_AXIS,
+        MATRIX
+    };
+
+    KDL::Rotation getRotation(Eigen::VectorXdRefConst data, RotationType type);
+
+    Eigen::VectorXd setRotation(const KDL::Rotation& data, RotationType type);
+
+    inline int getRotationTypeLength(RotationType type)
+    {
+        static int types[] = {4, 3, 3, 3, 3, 9};
+        return types[(int)type];
+    }
+
    /**
    * @brief randomColor Generates random opaque color.
    * @return Random color

--- a/exotica/include/exotica/Tools/Conversions.h
+++ b/exotica/include/exotica/Tools/Conversions.h
@@ -111,6 +111,18 @@ namespace exotica
         return ret;
     }
 
+    template <class Key, class Val>
+    void appendMap(std::map<Key,Val>& orig, const std::map<Key,Val>& extra)
+    {
+        orig.insert(extra.begin(),extra.end());
+    }
+
+    template <class Val>
+    void appendVector(std::vector<Val>& orig, const std::vector<Val>& extra)
+    {
+        orig.insert(orig.end(), extra.begin(),extra.end());
+    }
+
     KDL::Frame getFrame(Eigen::VectorXdRefConst val);
 
     bool contains(std::string key, const std::vector<std::string>& vec);

--- a/exotica/src/PlanningProblem.cpp
+++ b/exotica/src/PlanningProblem.cpp
@@ -56,6 +56,7 @@ namespace exotica
       PlanningProblemInitializer init(init_);
 
       TaskMaps.clear();
+      Tasks.clear();
 
       // Create the scene
       scene_.reset(new Scene());
@@ -82,19 +83,22 @@ namespace exotica
 
           Request.Frames.insert(Request.Frames.end(), frames.begin(), frames.end());
           TaskMaps[NewMap->getObjectName()] = NewMap;
+          Tasks.push_back(NewMap);
       }
 
       std::shared_ptr<KinematicResponse> Response = scene_->RequestKinematics(Request);
-      int i=0;
       id=0;
-      for(auto& map : TaskMaps)
+      int idJ=0;
+      for(int i=0; i<Tasks.size(); i++)
       {
-          map.second->Kinematics.Create(Response);
-          map.second->Id = i;
-          map.second->Start = id;
-          map.second->Length = map.second->taskSpaceDim();
-          i++;
-          id += map.second->Length;
+          Tasks[i]->Kinematics.Create(Response);
+          Tasks[i]->Id = i;
+          Tasks[i]->Start = id;
+          Tasks[i]->Length = Tasks[i]->taskSpaceDim();
+          Tasks[i]->StartJ = idJ;
+          Tasks[i]->LengthJ = Tasks[i]->taskSpaceJacobianDim();
+          id += Tasks[i]->Length;
+          idJ += Tasks[i]->LengthJ;
       }
 
       if (init.Maps.size() == 0)
@@ -106,6 +110,11 @@ namespace exotica
   TaskMap_map& PlanningProblem::getTaskMaps()
   {
     return TaskMaps;
+  }
+
+  TaskMap_vec& PlanningProblem::getTasks()
+  {
+      return Tasks;
   }
 
   Scene_ptr PlanningProblem::getScene()

--- a/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
@@ -66,7 +66,7 @@ namespace exotica
         if(init.W.rows()!=N) throw_named("W dimension mismatch! Expected "<<N<<", got "<<init.W.rows());
 
         Rho = Eigen::VectorXd::Ones(NumTasks);
-        y.data = Eigen::VectorXd::Zero(PhiN);
+        y.setZero(PhiN);
         W = Eigen::MatrixXd::Identity(N, N);
         W.diagonal() = init.W;
         Phi = y;

--- a/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
@@ -51,34 +51,32 @@ namespace exotica
 
     void UnconstrainedEndPoseProblem::Instantiate(UnconstrainedEndPoseProblemInitializer& init)
     {
-        Tasks = MapToVec(TaskMaps);
         NumTasks = Tasks.size();
-        Mapping.resize(NumTasks, 2);
-        int id=0;
+        PhiN = 0;
+        JN = 0;
         for(int i=0;i<NumTasks;i++)
         {
-            Mapping(i,0) = id;
-            Mapping(i,1) = Tasks[i]->taskSpaceDim();
-            id += Mapping(i,1);            
+            appendVector(y.map, Tasks[i]->getLieGroupIndices());
+            PhiN += Tasks[i]->Length;
+            JN += Tasks[i]->LengthJ;
         }
-        PhiN = Mapping.col(1).sum();
 
         N = scene_->getNumJoints();
 
         if(init.W.rows()!=N) throw_named("W dimension mismatch! Expected "<<N<<", got "<<init.W.rows());
 
         Rho = Eigen::VectorXd::Ones(NumTasks);
-        y = Eigen::VectorXd::Zero(PhiN);
+        y.data = Eigen::VectorXd::Zero(PhiN);
         W = Eigen::MatrixXd::Identity(N, N);
         W.diagonal() = init.W;
-        Phi = Eigen::VectorXd::Zero(PhiN);
-        J = Eigen::MatrixXd(PhiN, N);
+        Phi = y;
+        J = Eigen::MatrixXd(JN, N);
 
         if(init.Rho.rows()>0 && init.Rho.rows()!=NumTasks) throw_named("Invalide size of Rho (" << init.Rho.rows() << ") expected: "<< NumTasks);
         if(init.Goal.rows()>0 && init.Goal.rows()!=PhiN) throw_named("Invalide size of Rho (" << init.Goal.rows() << ") expected: "<< PhiN);
 
         if(init.Rho.rows()==NumTasks) Rho = init.Rho;
-        if(init.Goal.rows()==PhiN) y = init.Goal;
+        if(init.Goal.rows()==PhiN) y.data = init.Goal;
     }
 
     void UnconstrainedEndPoseProblem::Update(Eigen::VectorXdRefConst x)
@@ -86,7 +84,7 @@ namespace exotica
         scene_->Update(x);
         for(int i=0;i<NumTasks;i++)
         {
-            Tasks[i]->update(x, Phi.segment(Mapping(i, 0), Mapping(i, 1)), J.middleRows(Mapping(i, 0), Mapping(i, 1)));
+            Tasks[i]->update(x, Phi.data.segment(Tasks[i]->Start, Tasks[i]->Length), J.middleRows(Tasks[i]->StartJ, Tasks[i]->LengthJ));
         }
     }
 
@@ -94,7 +92,7 @@ namespace exotica
     {
         TaskMap_ptr task = TaskMaps.at(task_name);
         if(goal.rows()!=task->Length) throw_named("Invalid goal dimension "<<goal.rows()<<" expected "<<task->Length);
-        y.segment(task->Start, task->Length) = goal;
+        y.data.segment(task->Start, task->Length) = goal;
     }
 
     void UnconstrainedEndPoseProblem::setRho(const std::string & task_name, const double rho)
@@ -106,13 +104,13 @@ namespace exotica
     Eigen::VectorXd UnconstrainedEndPoseProblem::getGoal(const std::string & task_name)
     {
         TaskMap_ptr task = TaskMaps.at(task_name);
-        return y.segment(task->Start, task->Length);
+        return y.data.segment(task->Start, task->Length);
     }
 
     double UnconstrainedEndPoseProblem::getRho(const std::string & task_name)
     {
         TaskMap_ptr task = TaskMaps.at(task_name);
-        return y(task->Id);
+        return Rho(task->Id);
     }
 }
 

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -82,7 +82,7 @@ namespace exotica
       Q = Eigen::MatrixXd::Identity(N, N)*H_rate;
 
       Rho.assign(T, Eigen::VectorXd::Ones(NumTasks));
-      yref.data = Eigen::VectorXd::Zero(PhiN);
+      yref.setZero(PhiN);
       y.assign(T, yref);
       Phi = y;
       ydiff.assign(T, Eigen::VectorXd::Zero(JN));

--- a/exotica/src/TaskSpaceVector.cpp
+++ b/exotica/src/TaskSpaceVector.cpp
@@ -1,0 +1,49 @@
+#include <exotica/TaskSpaceVector.h>
+
+namespace exotica
+{
+
+    TaskVectorEntry::TaskVectorEntry(int inId_, int outId_, RotationType type_) :
+        inId(inId_), outId(outId_), type(type_)
+    {
+
+    }
+
+    TaskVectorEntry::TaskVectorEntry() :
+        inId(0), outId(0), type(RotationType::RPY)
+    {
+
+    }
+
+    TaskSpaceVector::TaskSpaceVector()
+    {
+
+    }
+
+    TaskSpaceVector& TaskSpaceVector::operator=(std::initializer_list<double> other)
+    {
+        if(other.size()!=data.rows()) throw_pretty("Wrong initializer size: " << other.size() << " expecting " << data.rows());
+        int i = 0;
+        for(double val : other)
+        {
+            data(i) = val;
+            i++;
+        }
+        return *this;
+    }
+
+    Eigen::VectorXd TaskSpaceVector::operator-(const TaskSpaceVector& other)
+    {
+        Eigen::VectorXd ret = data-other.data;
+        for(const TaskVectorEntry& id : map)
+        {
+            KDL::Rotation M1 = getRotation(data.segment(id.inId, getRotationTypeLength(id.type)), id.type);
+            KDL::Rotation M2 = getRotation(other.data.segment(id.inId, getRotationTypeLength(id.type)), id.type);
+            KDL::Vector rotvec = M1*(M2.Inverse()*M1).GetRot();
+            ret(id.outId) = rotvec[0];
+            ret(id.outId+1) = rotvec[1];
+            ret(id.outId+2) = rotvec[2];
+        }
+        return ret;
+    }
+}

--- a/exotica/src/TaskSpaceVector.cpp
+++ b/exotica/src/TaskSpaceVector.cpp
@@ -53,13 +53,11 @@ namespace exotica
         int iOut=0;
         for(const TaskVectorEntry& id : map)
         {
+            if(iIn<id.inId) ret.segment(iOut, id.inId-iIn) = data.segment(iIn, id.inId-iIn) - other.data.segment(iIn, id.inId-iIn);
+            iOut += id.inId-iIn;
+            iIn += id.inId-iIn;
             int len = getRotationTypeLength(id.type);
-            while(iIn<id.inId)
-            {
-                ret(iOut) = data(iIn) - other.data(iIn);
-                iIn++;
-                iOut++;
-            }
+
             KDL::Rotation M1 = getRotation(data.segment(id.inId, len), id.type);
             KDL::Rotation M2 = getRotation(other.data.segment(id.inId, len), id.type);
             KDL::Rotation M = M2.Inverse()*M1;
@@ -70,12 +68,7 @@ namespace exotica
             iOut+=3;
             iIn+=len;
         }
-        while(iIn<data.rows())
-        {
-            ret(iOut) = data(iIn) - other.data(iIn);
-            iIn++;
-            iOut++;
-        }
+        if(iIn<data.rows()) ret.segment(iOut, data.rows()-iIn) = data.segment(iIn, data.rows()-iIn) - other.data.segment(iIn, data.rows()-iIn);
         return ret;
     }
 }

--- a/exotica/src/TaskSpaceVector.cpp
+++ b/exotica/src/TaskSpaceVector.cpp
@@ -3,14 +3,14 @@
 namespace exotica
 {
 
-    TaskVectorEntry::TaskVectorEntry(int inId_, int outId_, RotationType type_) :
-        inId(inId_), outId(outId_), type(type_)
+    TaskVectorEntry::TaskVectorEntry(int inId_, RotationType type_) :
+        inId(inId_), type(type_)
     {
 
     }
 
     TaskVectorEntry::TaskVectorEntry() :
-        inId(0), outId(0), type(RotationType::RPY)
+        inId(0), type(RotationType::RPY)
     {
 
     }
@@ -32,17 +32,49 @@ namespace exotica
         return *this;
     }
 
-    Eigen::VectorXd TaskSpaceVector::operator-(const TaskSpaceVector& other)
+    void TaskSpaceVector::setZero(int N)
     {
-        Eigen::VectorXd ret = data-other.data;
+
+        data = Eigen::VectorXd::Zero(N);
         for(const TaskVectorEntry& id : map)
         {
-            KDL::Rotation M1 = getRotation(data.segment(id.inId, getRotationTypeLength(id.type)), id.type);
-            KDL::Rotation M2 = getRotation(other.data.segment(id.inId, getRotationTypeLength(id.type)), id.type);
-            KDL::Vector rotvec = M1*(M2.Inverse()*M1).GetRot();
-            ret(id.outId) = rotvec[0];
-            ret(id.outId+1) = rotvec[1];
-            ret(id.outId+2) = rotvec[2];
+            int len = getRotationTypeLength(id.type);
+            data.segment(id.inId,len) = setRotation(KDL::Rotation(), id.type);
+        }
+    }
+
+    Eigen::VectorXd TaskSpaceVector::operator-(const TaskSpaceVector& other)
+    {
+        if(data.rows() != other.data.rows()) throw_pretty("Task space vector sizes do not match!");
+        int entrySize = 0;
+        for(const TaskVectorEntry& id : map) entrySize += getRotationTypeLength(id.type);
+        Eigen::VectorXd ret(data.rows()+map.size()*3-map.size()*entrySize);
+        int iIn=0;
+        int iOut=0;
+        for(const TaskVectorEntry& id : map)
+        {
+            int len = getRotationTypeLength(id.type);
+            while(iIn<id.inId)
+            {
+                ret(iOut) = data(iIn) - other.data(iIn);
+                iIn++;
+                iOut++;
+            }
+            KDL::Rotation M1 = getRotation(data.segment(id.inId, len), id.type);
+            KDL::Rotation M2 = getRotation(other.data.segment(id.inId, len), id.type);
+            KDL::Rotation M = M2.Inverse()*M1;
+            KDL::Vector rotvec = M1*(M.GetRot());
+            ret(iOut) = rotvec[0];
+            ret(iOut+1) = rotvec[1];
+            ret(iOut+2) = rotvec[2];
+            iOut+=3;
+            iIn+=len;
+        }
+        while(iIn<data.rows())
+        {
+            ret(iOut) = data(iIn) - other.data(iIn);
+            iIn++;
+            iOut++;
         }
         return ret;
     }

--- a/exotica/src/Tools.cpp
+++ b/exotica/src/Tools.cpp
@@ -56,7 +56,7 @@ namespace exotica
             {
                 KDL::Vector axis(data(0), data(1), data(2));
                 double angle = axis.Norm();
-                if(abs(angle)>1e-10)
+                if(fabs(angle)>1e-10)
                 {
                     return KDL::Rotation::Rot(axis, angle);
                 }

--- a/exotica/src/Tools.cpp
+++ b/exotica/src/Tools.cpp
@@ -39,6 +39,63 @@
 namespace exotica
 {
 
+    KDL::Rotation getRotation(Eigen::VectorXdRefConst data, RotationType type)
+    {
+        switch(type)
+        {
+        case RotationType::QUATERNION:
+            return KDL::Rotation::Quaternion(data(0), data(1), data(2), data(3));
+        case RotationType::RPY:
+            return KDL::Rotation::RPY(data(0), data(1), data(2));
+        case RotationType::ZYX:
+            return KDL::Rotation::EulerZYX(data(0), data(1), data(2));
+        case RotationType::ZYZ:
+            return KDL::Rotation::EulerZYZ(data(0), data(1), data(2));
+        case RotationType::ANGLE_AXIS:
+            {
+                KDL::Vector axis(data(0), data(1), data(2));
+                double angle = axis.Norm();
+                return KDL::Rotation::Rot(axis/angle, angle);
+            }
+        case RotationType::MATRIX:
+            return KDL::Rotation(data(0), data(1), data(2),
+                                 data(3), data(4), data(5),
+                                 data(6), data(7), data(8));
+        }
+        throw_pretty("Unknown rotation represntation type!");
+    }
+
+    Eigen::VectorXd setRotation(const KDL::Rotation& data, RotationType type)
+    {
+        Eigen::VectorXd ret;
+        switch(type)
+        {
+        case RotationType::QUATERNION:
+            ret.resize(4);
+            data.GetQuaternion(ret(0), ret(1), ret(2), ret(3));
+            return ret;
+        case RotationType::RPY:
+            ret.resize(3);
+            data.GetRPY(ret(0), ret(1), ret(2));
+            return ret;
+        case RotationType::ZYX:
+            ret.resize(3);
+            data.GetEulerZYX(ret(0), ret(1), ret(2));
+            return ret;
+        case RotationType::ZYZ:
+            ret.resize(3);
+            data.GetEulerZYZ(ret(0), ret(1), ret(2));
+            return ret;
+        case RotationType::ANGLE_AXIS:
+            ret = Eigen::Map<const Eigen::Vector3d>(data.GetRot().data);
+            return ret;
+        case RotationType::MATRIX:
+            ret = Eigen::Map<const Eigen::VectorXd>(data.data, 9);
+            return ret;
+        }
+        throw_pretty("Unknown rotation represntation type!");
+    }
+
     std_msgs::ColorRGBA randomColor()
     {
         std_msgs::ColorRGBA ret;

--- a/exotica/src/Tools.cpp
+++ b/exotica/src/Tools.cpp
@@ -44,6 +44,7 @@ namespace exotica
         switch(type)
         {
         case RotationType::QUATERNION:
+            if(data.sum()==0.0) throw_pretty("Invalid quaternion transform!");
             return KDL::Rotation::Quaternion(data(0), data(1), data(2), data(3));
         case RotationType::RPY:
             return KDL::Rotation::RPY(data(0), data(1), data(2));
@@ -55,9 +56,17 @@ namespace exotica
             {
                 KDL::Vector axis(data(0), data(1), data(2));
                 double angle = axis.Norm();
-                return KDL::Rotation::Rot(axis/angle, angle);
+                if(abs(angle)>1e-10)
+                {
+                    return KDL::Rotation::Rot(axis, angle);
+                }
+                else
+                {
+                    return KDL::Rotation();
+                }
             }
         case RotationType::MATRIX:
+            if(data.sum()==0.0) throw_pretty("Invalid matrix transform!");
             return KDL::Rotation(data(0), data(1), data(2),
                                  data(3), data(4), data(5),
                                  data(6), data(7), data(8));


### PR DESCRIPTION
Lie group algebra:
 - ```TaskSpaceVector``` handles the task space operations involving correct handling of rotation frames
    - Orientations can be stored in multiple formats: Quaternion (4d), RPY/EulerZYX/EulerZYZ/AxixAngle (3d) or full matrix (9d)
    - A task space vector may contain a mixture of Lie group handled sub vectors and and regula values. The above class will selectively apply the operator as requested. Task maps can specify if they produce a rotational task vector in one of the above formats (only ```EffOrientation``` and ```EffFrame``` use this feature). 
    - Subtraction of two ```TaskSpaceVector```s will handle orientation frames using the Lie group algebra. The result will be the angular component of the twist of the two frames, regardless of how the frame is stored (e.g. RPY-RPY=twist, or Quat-Quat=twist).
    - ```TaskSpaceVector``` can be initialized to "zero" configuration using ```setZero``` method. Quaternion and Matrix components get initialized to identity.

Task maps:
 - ```EffOrientation``` and ```EffFrame``` implement orientation task map and full frame task map.
     - Representation of the rotation part can be chosen via initalizer parameter: ```<Type>Quaternion</Type>```.
 - Helper functions to convert a ```KDL::Frame``` to a task vector of the corresponding type are implemented int the ```Tools.cpp```.
 - AICO and OMPL examples now use the ```EffFrame``` task map.
 - Task map test program tests all representations.


Merge PR #59 first!