### PR TITLE
Remove unused XML_CHECK definition

### DIFF
--- a/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
+++ b/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
@@ -39,7 +39,6 @@
 #undef large
 #include <lapack/clapack.h>
 
-#define XML_CHECK(x) {xmltmp=handle.FirstChildElement(x).ToElement();if (!xmltmp) throw_named("XML element '"<<x<<"' does not exist!");}
 
 REGISTER_MOTIONSOLVER_TYPE("IKsolver", exotica::IKsolver)
 

--- a/exotations/task_maps/dmesh_ros/src/dmesh_ros.cpp
+++ b/exotations/task_maps/dmesh_ros/src/dmesh_ros.cpp
@@ -33,7 +33,6 @@
 #include <dmesh_ros/dmesh_ros.h>
 #include <dmesh_ros/DMeshVertexInitializer.h>
 REGISTER_TASKMAP_TYPE("DMeshROS", exotica::DMeshROS);
-#define XML_CHECK(x) {xmltmp=handle.FirstChildElement(x).ToElement();if (!xmltmp) throw_named("XML element '"<<x<<"' does not exist!");}
 
 namespace exotica
 {

--- a/exotations/task_maps/task_map/src/IMesh.cpp
+++ b/exotations/task_maps/task_map/src/IMesh.cpp
@@ -31,7 +31,6 @@
  */
 
 #include "task_map/IMesh.h"
-#define XML_CHECK(x) {xmltmp=handle.FirstChildElement(x).ToElement();if (!xmltmp) throw_named("XML element '"<<x<<"' does not exist!");}
 
 //#define DEBUG_MODE
 REGISTER_TASKMAP_TYPE("IMesh", exotica::IMesh);

--- a/exotica/src/Problems/SamplingProblem.cpp
+++ b/exotica/src/Problems/SamplingProblem.cpp
@@ -35,7 +35,6 @@
 #include <exotica/Setup.h>
 
 REGISTER_PROBLEM_TYPE("SamplingProblem", exotica::SamplingProblem)
-#define XML_CHECK(x) {xmltmp=handle.FirstChildElement(x).ToElement();if (!xmltmp) throw_named("XML element '"<<x<<"' does not exist!");}
 
 namespace exotica
 {

--- a/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
@@ -36,7 +36,6 @@
 
 REGISTER_PROBLEM_TYPE("UnconstrainedEndPoseProblem", exotica::UnconstrainedEndPoseProblem)
 
-#define XML_CHECK(x) {xmltmp=handle.FirstChildElement(x).ToElement();if (!xmltmp) throw_named("XML element '"<<x<<"' does not exist!");}
 
 namespace exotica
 {


### PR DESCRIPTION
Randomly stumbled across these unused remnants, should be good to go from these files as the initialisation is done somewhere else.