### PR TITLE
Added whole robot state set/get methods

### DIFF
--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -193,6 +193,16 @@ namespace exotica
               return ControlledJointsNames;
             }
 
+            std::vector<std::string> getModelJointNames()
+            {
+              return ModleJointsNames;
+            }
+
+            Eigen::VectorXd getModelState();
+            std::map<std::string, double> getModelStateMap();
+            void setModelState(Eigen::VectorXdRefConst x);
+            void setModelState(std::map<std::string, double> x);
+
             std::vector<std::shared_ptr<KinematicElement>> getTree() {return Tree;}
             std::map<std::string, std::shared_ptr<KinematicElement>> getTreeMap() {return TreeMap;}
             bool Debug;
@@ -217,6 +227,7 @@ namespace exotica
             std::shared_ptr<KinematicElement> Root;
             std::vector<std::shared_ptr<KinematicElement>> ControlledJoints;
             std::map<std::string, std::shared_ptr<KinematicElement>> ControlledJointsMap;
+            std::map<std::string, std::shared_ptr<KinematicElement>> ModelJointsMap;
             std::vector<std::string> ModleJointsNames;
             std::vector<std::string> ControlledJointsNames;
             std::shared_ptr<KinematicResponse> Solution;

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -195,7 +195,7 @@ namespace exotica
 
             std::vector<std::string> getModelJointNames()
             {
-              return ModleJointsNames;
+              return ModelJointsNames;
             }
 
             Eigen::VectorXd getModelState();
@@ -228,7 +228,7 @@ namespace exotica
             std::vector<std::shared_ptr<KinematicElement>> ControlledJoints;
             std::map<std::string, std::shared_ptr<KinematicElement>> ControlledJointsMap;
             std::map<std::string, std::shared_ptr<KinematicElement>> ModelJointsMap;
-            std::vector<std::string> ModleJointsNames;
+            std::vector<std::string> ModelJointsNames;
             std::vector<std::string> ControlledJointsNames;
             std::shared_ptr<KinematicResponse> Solution;
             KinematicRequestFlags Flags;

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -242,6 +242,11 @@ namespace exotica
       robot_model::RobotModelPtr getRobotModel();
       void getJointNames(std::vector<std::string> & joints);
       std::vector<std::string> getJointNames();
+      std::vector<std::string> getModelJointNames();
+      Eigen::VectorXd getModelState();
+      std::map<std::string, double> getModelStateMap();
+      void setModelState(Eigen::VectorXdRefConst x);
+      void setModelState(std::map<std::string, double> x);
 
       BASE_TYPE getBaseType()
       {

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -600,6 +600,32 @@ namespace exotica
   {
     return kinematica_.getJointNames();
   }
+
+  std::vector<std::string> Scene::getModelJointNames()
+  {
+    return kinematica_.getModelJointNames();
+  }
+
+  Eigen::VectorXd Scene::getModelState()
+  {
+    return kinematica_.getModelState();
+  }
+
+  std::map<std::string, double> Scene::getModelStateMap()
+  {
+    return kinematica_.getModelStateMap();
+  }
+
+  void Scene::setModelState(Eigen::VectorXdRefConst x)
+  {
+    kinematica_.setModelState(x);
+  }
+
+  void Scene::setModelState(std::map<std::string, double> x)
+  {
+    kinematica_.setModelState(x);
+  }
+
 }
 //	namespace exotica
 

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -467,6 +467,11 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("Update", &Scene::Update);
     scene.def("getJointNames", (std::vector<std::string> (Scene::*)()) &Scene::getJointNames);
     scene.def("getSolver", &Scene::getSolver, py::return_value_policy::reference_internal);
+    scene.def("getModelJointNames", &Scene::getModelJointNames);
+    scene.def("getModelState", &Scene::getModelState);
+    scene.def("getModelStateMap", &Scene::getModelStateMap);
+    scene.def("setModelState", (void (Scene::*)(Eigen::VectorXdRefConst)) &Scene::setModelState);
+    scene.def("setModelStateMap", (void (Scene::*)(std::map<std::string, double>)) &Scene::setModelState);
 
     py::module kin = module.def_submodule("Kinematics","Kinematics submodule.");
     py::class_<KinematicTree, std::shared_ptr<KinematicTree>> kinematicTree(kin, "KinematicTree");


### PR DESCRIPTION
- `KinematicTree::setModelJointState` and `KinematicTree::setModelJointStateMap` sets the states of all joints (even the ones that are not controlled.
- Respective getters have been added.
- All joint names can be retrieved using `KinematicTree::getModelJointNames`
- `Scene` exposes these methods too
- Python wrappers are included

Fixes #63