### PR TITLE
Move start state to the problem

### DIFF
--- a/examples/exotica_examples/src/generic.cpp
+++ b/examples/exotica_examples/src/generic.cpp
@@ -99,7 +99,8 @@ void run()
                 0.5 + sin(t * M_PI * 0.5) * 0.2 ,0 ,0 ,0};
 
         // Solve the problem using the IK solver
-        any_solver->Solve(q, solution);
+        my_problem->setStartState(q);
+        any_solver->Solve(solution);
 
         double time = ros::Duration((ros::WallTime::now() - start_time).toSec()).toSec();
         ROS_INFO_STREAM_THROTTLE(0.5,

--- a/examples/exotica_examples/src/manual.cpp
+++ b/examples/exotica_examples/src/manual.cpp
@@ -90,7 +90,8 @@ void run()
                 0.5 + sin(t * M_PI * 0.5) * 0.2 ,0 ,0 ,0};
 
         // Solve the problem using the IK solver
-        any_solver->Solve(q, solution);
+        my_problem->setStartState(q);
+        any_solver->Solve(solution);
 
         double time = ros::Duration((ros::WallTime::now() - start_time).toSec()).toSec();
         ROS_INFO_STREAM_THROTTLE(0.5, "Finished solving in "<<time<<"s. Solution ["<<solution<<"]");

--- a/examples/exotica_examples/src/planner.cpp
+++ b/examples/exotica_examples/src/planner.cpp
@@ -83,7 +83,7 @@ void run()
     {
         ros::WallTime start_time = ros::WallTime::now();
         // Solve the problem using the AICO solver
-        any_solver->Solve(q, solution);
+        any_solver->Solve(solution);
         double time = ros::Duration(
                     (ros::WallTime::now() - start_time).toSec()).toSec();
         ROS_INFO_STREAM_THROTTLE(0.5, "Finished solving ("<<time<<"s)");

--- a/examples/exotica_examples/src/xml.cpp
+++ b/examples/exotica_examples/src/xml.cpp
@@ -81,7 +81,8 @@ void run()
                 0.5 + sin(t * M_PI * 0.5) * 0.2 ,0 ,0 ,0};
 
         // Solve the problem using the IK solver
-        any_solver->Solve(q, solution);
+        my_problem->setStartState(q);
+        any_solver->Solve(solution);
 
         double time = ros::Duration((ros::WallTime::now() - start_time).toSec()).toSec();
         ROS_INFO_STREAM_THROTTLE(0.5, "Finished solving in "<<time<<"s. Solution ["<<solution<<"]");

--- a/exotations/solvers/aico/include/aico/AICOsolver.h
+++ b/exotations/solvers/aico/include/aico/AICOsolver.h
@@ -100,7 +100,7 @@ namespace exotica
        * @param solution This will be filled with the solution in joint space.
        * @return SUCESS if solution has been found, corresponding error code if not.
        */
-      void Solve(Eigen::VectorXdRefConst q0, Eigen::MatrixXd & solution);
+      void Solve(Eigen::MatrixXd & solution);
 
       /**
        * \brief Solves the problem

--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -119,8 +119,9 @@ namespace exotica
     initMessages();
   }
 
-  void AICOsolver::Solve(Eigen::VectorXdRefConst q0, Eigen::MatrixXd & solution)
+  void AICOsolver::Solve(Eigen::MatrixXd & solution)
   {
+    Eigen::VectorXd q0 = prob_->applyStartState();
     std::vector<Eigen::VectorXd> q_init;
     q_init.resize(T, Eigen::VectorXd::Zero(q0.rows()));
     for (int i = 0; i < q_init.size(); i++)
@@ -130,6 +131,8 @@ namespace exotica
 
   void AICOsolver::Solve(const std::vector<Eigen::VectorXd>& q_init, Eigen::MatrixXd & solution)
   {
+    prob_->setStartState(q_init[0]);
+    prob_->applyStartState();
     ros::Time startTime = ros::Time::now();
     ROS_WARN_STREAM("AICO: Setting up the solver");
     updateCount = 0;

--- a/exotations/solvers/ik_solver/include/ik_solver/IKSolver.h
+++ b/exotations/solvers/ik_solver/include/ik_solver/IKSolver.h
@@ -53,7 +53,7 @@ namespace exotica
 
       virtual void Instantiate(IKsolverInitializer& init);
 
-      virtual void Solve(Eigen::VectorXdRefConst q0, Eigen::MatrixXd & solution);
+      virtual void Solve(Eigen::MatrixXd & solution);
 
       virtual void specifyProblem(PlanningProblem_ptr pointer);
 

--- a/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
+++ b/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
@@ -128,9 +128,10 @@ namespace exotica
         return iterations_;
     }
 
-    void IKsolver::Solve(Eigen::VectorXdRefConst q0, Eigen::MatrixXd & solution)
+    void IKsolver::Solve(Eigen::MatrixXd & solution)
     {
         if(!prob_) throw_named("Solver has not been initialized!");
+        Eigen::VectorXd q0 = prob_->applyStartState();
 
         ros::Time start = ros::Time::now();
         if (prob_->N != q0.rows()) throw_named("Wrong size q0 size=" << q0.rows() << ", required size="<< prob_->N);

--- a/exotations/solvers/ompl_solver/include/ompl_solver/OMPLsolver.h
+++ b/exotations/solvers/ompl_solver/include/ompl_solver/OMPLsolver.h
@@ -63,7 +63,7 @@ namespace exotica
        */
       virtual void specifyProblem(PlanningProblem_ptr pointer);
 
-      void Solve(Eigen::VectorXdRefConst q0, Eigen::MatrixXd & solution);
+      void Solve(Eigen::MatrixXd & solution);
 
       /*
        * \brief Get planning problem

--- a/exotations/solvers/ompl_solver/src/OMPLsolver.cpp
+++ b/exotations/solvers/ompl_solver/src/OMPLsolver.cpp
@@ -72,9 +72,9 @@ namespace exotica
     return ret;
   }
 
-  void OMPLsolver::Solve(Eigen::VectorXdRefConst q0,
-      Eigen::MatrixXd & solution)
+  void OMPLsolver::Solve(Eigen::MatrixXd & solution)
   {
+    Eigen::VectorXd q0 = prob_->applyStartState();
     setGoalState(prob_->goal_);
     if (base_solver_->solve(q0, solution))
     {

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -202,6 +202,7 @@ namespace exotica
             std::map<std::string, double> getModelStateMap();
             void setModelState(Eigen::VectorXdRefConst x);
             void setModelState(std::map<std::string, double> x);
+            Eigen::VectorXd getControlledState();
 
             std::vector<std::shared_ptr<KinematicElement>> getTree() {return Tree;}
             std::map<std::string, std::shared_ptr<KinematicElement>> getTreeMap() {return TreeMap;}

--- a/exotica/include/exotica/MotionSolver.h
+++ b/exotica/include/exotica/MotionSolver.h
@@ -50,7 +50,7 @@ namespace exotica
         virtual ~MotionSolver() {}
         virtual void InstantiateBase(const Initializer& init);
         virtual void specifyProblem(PlanningProblem_ptr pointer);
-        virtual void Solve(Eigen::VectorXdRefConst q0,  Eigen::MatrixXd & solution) = 0;
+        virtual void Solve(Eigen::MatrixXd & solution) = 0;
         PlanningProblem_ptr getProblem() {return problem_;}
         virtual std::string print(std::string prepend);
 

--- a/exotica/include/exotica/PlanningProblem.h
+++ b/exotica/include/exotica/PlanningProblem.h
@@ -59,12 +59,16 @@ namespace exotica
         TaskMap_vec& getTasks();
         Scene_ptr getScene();
         virtual std::string print(std::string prepend);
+        void setStartState(Eigen::VectorXdRefConst x);
+        Eigen::VectorXd getStartState();
+        Eigen::VectorXd applyStartState();
 
     protected:
         Scene_ptr scene_;
         TaskMap_map TaskMaps;
         TaskMap_vec Tasks;
         KinematicRequestFlags Flags;
+        Eigen::VectorXd startState;
 
     };
 

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -244,6 +244,7 @@ namespace exotica
       std::vector<std::string> getJointNames();
       std::vector<std::string> getModelJointNames();
       Eigen::VectorXd getModelState();
+      Eigen::VectorXd getControlledState();
       std::map<std::string, double> getModelStateMap();
       void setModelState(Eigen::VectorXdRefConst x);
       void setModelState(std::map<std::string, double> x);

--- a/exotica/init/PlanningProblem.in
+++ b/exotica/init/PlanningProblem.in
@@ -2,3 +2,4 @@ include <exotica/SceneInitializer>
 extend <exotica/Object>
 Required exotica::Initializer PlanningScene; # SceneInitializer
 Optional std::vector<exotica::Initializer> Maps = std::vector<exotica::Initializer>();
+Optional Eigen::VectorXd StartState = Eigen::VectorXd();

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -499,4 +499,14 @@ void KinematicTree::setModelState(std::map<std::string, double> x)
     }
 }
 
+Eigen::VectorXd KinematicTree::getControlledState()
+{
+    Eigen::VectorXd x(NumControlledJoints);
+    for(int i=0; i<ControlledJoints.size(); i++)
+    {
+        x(i) = TreeState(ControlledJoints[i]->Id);
+    }
+    return x;
+}
+
 }

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -626,6 +626,11 @@ namespace exotica
     kinematica_.setModelState(x);
   }
 
+  Eigen::VectorXd Scene::getControlledState()
+  {
+      return kinematica_.getControlledState();
+  }
+
 }
 //	namespace exotica
 

--- a/exotica_python/scripts/example_aico.py
+++ b/exotica_python/scripts/example_aico.py
@@ -21,7 +21,7 @@ for t in range(0,problem.T):
         problem.setRho('Frame',1e5,t)
         problem.setGoal('Frame',figureEight(t*problem.tau),t)
 
-solution = solver.solve(array([0.0]*7))
+solution = solver.solve()
 
 plot(solution)
 

--- a/exotica_python/scripts/example_ik.py
+++ b/exotica_python/scripts/example_ik.py
@@ -21,7 +21,8 @@ q=array([0.0]*7)
 print('Publishing IK')
 while not is_shutdown():
     problem.setGoal('Position',figureEight(t))
-    q = solver.solve(q)[0]
+    problem.startState = q
+    q = solver.solve()[0]
     publishPose(q, problem)    
     sleep(dt)
     t=t+dt

--- a/exotica_python/scripts/example_ompl.py
+++ b/exotica_python/scripts/example_ompl.py
@@ -11,7 +11,7 @@ problem = exo.Setup.createProblem(prob)
 solver = exo.Setup.createSolver(sol)
 solver.specifyProblem(problem)
 
-solution = solver.solve(array([0.0]*7))
+solution = solver.solve()
 
 plot(solution)
 

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -104,10 +104,10 @@ void addInitializers(py::module& module)
     inits.def("loadXMLFull", &loadFromXML, "Loads initializer from XML", py::arg("xml"), py::arg("solver_name")=std::string(""), py::arg("problem_name")=std::string(""), py::arg("parseAsXMLString")=false);
 }
 
-Eigen::MatrixXd Solve(std::shared_ptr<MotionSolver> sol, Eigen::VectorXd q0)
+Eigen::MatrixXd Solve(std::shared_ptr<MotionSolver> sol)
 {
     Eigen::MatrixXd ret;
-    sol->Solve(q0, ret);
+    sol->Solve(ret);
     return ret;
 }
 
@@ -407,13 +407,14 @@ PYBIND11_MODULE(_pyexotica, module)
 
     py::class_<MotionSolver, std::shared_ptr<MotionSolver>, Object> motionSolver(module, "MotionSolver");
     motionSolver.def("specifyProblem", &MotionSolver::specifyProblem, "Assign problem to the solver", py::arg("planningProblem"));
-    motionSolver.def("solve", [](std::shared_ptr<MotionSolver> sol, Eigen::VectorXd q0){return Solve(sol, q0);}, "Solve the problem", py::arg("q0"));
+    motionSolver.def("solve", [](std::shared_ptr<MotionSolver> sol){return Solve(sol);}, "Solve the problem");
     motionSolver.def("getProblem", &MotionSolver::getProblem, py::return_value_policy::reference_internal);
 
     py::class_<PlanningProblem, std::shared_ptr<PlanningProblem>, Object> planningProblem(module, "PlanningProblem");
     planningProblem.def("getTasks", &PlanningProblem::getTasks, py::return_value_policy::reference_internal);
     planningProblem.def("getScene", &PlanningProblem::getScene, py::return_value_policy::reference_internal);
     planningProblem.def("__repr__", &PlanningProblem::print, "String representation of the object", py::arg("prepend")=std::string(""));
+    planningProblem.def_property("startState", &PlanningProblem::getStartState, &PlanningProblem::setStartState);
 
     // Problem types
     py::module prob = module.def_submodule("Problems","Problem types");


### PR DESCRIPTION
- Start state `q0` is now a variable inside the `PlanningProblem` with accessor functions.
- Start state has to 1) specify all robot joint positions (including underactuated and uncontrolled ones), or 2) only the controlled joints (other joints will remain zero if not set otherwise).
- `Solve()` no longer accepts `q0` as argument. Set this using `PlanningProblem::setStartState()` or in the initializer.
- Each `Solve()` function has to copy/apply the full start state to the Scene. Use `PlanningProblem::applyStartState()` to do this. The method returns the controlled state extracted from the full state and it can be used as `q0` (same as before, see changes in the solvers).
- Examples and python wrapping have been updated.

Fixes #64