### PR TITLE
Bring Continuous Integration back online

### DIFF
--- a/.ci/before_install.sh
+++ b/.ci/before_install.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 set -xe
-wget https://bitbucket.org/eigen/eigen/get/3.2.6.zip
-unzip 3.2.6.zip
-cd eigen-eigen-c58038c56923
-mkdir build
-cd build
-cmake ..
-sudo make install
-cd ../..
+wget http://terminator.robots.inf.ed.ac.uk/apt/libeigen3-dev.deb
+sudo dpkg -i libeigen3-dev.deb
+rm libeigen3-dev.deb
+# wget https://bitbucket.org/eigen/eigen/get/3.2.6.zip
+# unzip 3.2.6.zip
+# cd eigen-eigen-c58038c56923
+# mkdir build
+# cd build
+# cmake ..
+# sudo make install
+# cd ../..

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,8 @@ sudo: required
 dist: trusty
 cache:
 - apt
-#- ccache
+- ccache
 language: generic
-compiler:
-- gcc
 env:
   global:
   - CATKIN_WS=~/catkin_ws
@@ -38,6 +36,9 @@ script:
 # Run tests
 - source /opt/ros/indigo/setup.bash
 - source devel/setup.bash
+- echo $ROS_PACKAGE_PATH
+- which rosrun
+- export PATH=/opt/ros/$CI_ROS_DISTRO/bin:$PATH
 - rosrun exotica test_initializers
 - rosrun task_map test_maps
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ install:
 - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
 - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
 - sudo apt-get update -qq
-- sudo apt-get install -qq -y python-rosdep python-catkin-tools
-- sudo pip install -U catkin_tools
+- sudo apt-get install -qq -y python-rosdep python-catkin-tools python-catkin-pkg
 - sudo rosdep init
 - rosdep update
 - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,15 @@ env:
   - CI_ROS_DISTRO="indigo"
   - secure: "smFIa1qA533FrLwuCW9AtegXk2bs0C2swDJWXWAikCSgET+fpF7DsGXAeE407PeZQBodnG/ZO3BODyE8orNvszBsNlK0QUx68kp8V2fgicg1V/PqlfhhUCNAZlhnI2xas/dZhvl4Ao8rfY1GZlyfms279yJljGdnVFiEyqQzQtiIN/komwpZKT7flTon9RrZ7QK5+N0nHA+17mX9Nl0L7H+pd2h3vBd7Wz4eb5S8O14zeuTcMcxlxJb8WP4W5KvHIwmiWFluhFamedc45LVXhJb0gECm7nNx1Qyrf1MQdRlBlWJ16AaxmHgdmiONQrc0/U7L2zs7aUfedJC9lmxTwCcQSTrdbO27e4nnb4VPptXITtGM2/8yn+m1pQzRNyJbrCcQyRilPPSRfhrQ24oaiingOATH+BCJ/sTkZTB8/9qjcMXkk7zPIMHTjGwonvyot33ftwlLMmu3pwm23dHcTttuEBlAjngDIarWhEFhZwvO6N9/vp478b1RJpFzDUgIZsbZWA3w6JjSkl49jXjLVn9ni5ciIs6rA6jo9MnVlVN9uLqOdJiavLRuakt6B2bzoU8Ghmz8JpcaBdRG2LhLb1HDCFdMehnTmmpcrQoUAgW6mQxJvUt1GV7LsODR1vhCb+zDh30zbCSKDDZQLjiQOMb1DAv7qrnfr+4MDkcxLbk="
 before_install:
-- bash $TRAVIS_BUILD_DIR/.ci/before_install.sh >> /dev/null
-install:
-- export PATH=/usr/bin/:$PATH # work-around Travis PYTHONPATH bug, cf. https://github.com/travis-ci/travis-ci/issues/8048
+- sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
 - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
 - sudo apt-get update -qq
+install:
+- export PATH=/usr/bin/:$PATH # work-around Travis PYTHONPATH bug, cf. https://github.com/travis-ci/travis-ci/issues/8048
+- bash $TRAVIS_BUILD_DIR/.ci/before_install.sh >> /dev/null
+- sudo apt-get install -qq g++-4.9
+- sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 90
 - sudo apt-get install -qq -y python-rosdep python-catkin-tools python-catkin-pkg
 - sudo rosdep init
 - rosdep update

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,6 @@ script:
 # Run tests
 - source /opt/ros/indigo/setup.bash
 - source devel/setup.bash
-- echo $ROS_PACKAGE_PATH
-- which rosrun
-- export PATH=/opt/ros/$CI_ROS_DISTRO/bin:$PATH
 - rosrun exotica test_initializers
 - rosrun task_map test_maps
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
 - rosdep update
 - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO
 script:
-- source /opt/ros/indigo/setup.bash
+- source /opt/ros/$CI_ROS_DISTRO/setup.bash
 - mkdir -p $CATKIN_WS_SRC
 - ln -s $TRAVIS_BUILD_DIR $CATKIN_WS_SRC
 - cd $CATKIN_WS_SRC
@@ -35,8 +35,7 @@ script:
 - cd ..
 - catkin config --init
 - catkin build -i
-after_success:
-  # Run tests
+# Run tests
 - source /opt/ros/indigo/setup.bash
 - source devel/setup.bash
 - rosrun exotica test_initializers

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,8 @@ install:
 - sudo rosdep init
 - rosdep update
 - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO
-- sudo pip install -U catkin_tools
 script:
 - source /opt/ros/indigo/setup.bash
-- echo $PYTHONPATH
 - mkdir -p $CATKIN_WS_SRC
 - ln -s $TRAVIS_BUILD_DIR $CATKIN_WS_SRC
 - cd $CATKIN_WS_SRC

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
 - sudo rosdep init
 - rosdep update
 - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO
+- sudo apt-get install -qq -y ros-$CI_ROS_DISTRO-rosbash
 script:
 - source /opt/ros/$CI_ROS_DISTRO/setup.bash
 - mkdir -p $CATKIN_WS_SRC

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ install:
 - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO
 - sudo pip install -U catkin_tools
 script:
-- source /opt/ros/$CI_ROS_DISTRO/setup.bash
+- source /opt/ros/indigo/setup.bash
+- echo $PYTHONPATH
 - mkdir -p $CATKIN_WS_SRC
 - ln -s $TRAVIS_BUILD_DIR $CATKIN_WS_SRC
 - cd $CATKIN_WS_SRC

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
 - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
 - sudo apt-get update -qq
 - sudo apt-get install -qq -y python-rosdep python-catkin-tools
+- sudo pip install -U catkin_tools
 - sudo rosdep init
 - rosdep update
 - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
 - sudo rosdep init
 - rosdep update
 - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO
+- sudo pip install -U catkin_tools
 script:
 - source /opt/ros/$CI_ROS_DISTRO/setup.bash
 - mkdir -p $CATKIN_WS_SRC

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
 before_install:
 - bash $TRAVIS_BUILD_DIR/.ci/before_install.sh >> /dev/null
 install:
+- export PATH=/usr/bin/:$PATH # work-around Travis PYTHONPATH bug, cf. https://github.com/travis-ci/travis-ci/issues/8048
 - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
 - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
 - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ script:
 # Run tests
 - source /opt/ros/indigo/setup.bash
 - source devel/setup.bash
+- roscore & # detached core
 - rosrun exotica test_initializers
 - rosrun task_map test_maps
 before_deploy:

--- a/exotica/CMakeLists.txt
+++ b/exotica/CMakeLists.txt
@@ -10,7 +10,6 @@ set(MSG_DEPS
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   message_generation
-  moveit_ros_planning_interface
   moveit_core
   tf
   kdl_parser
@@ -59,7 +58,7 @@ GenInitializers()
 catkin_package(
   INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR} include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS}
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS roscpp  message_runtime moveit_ros_planning_interface moveit_core tf kdl_parser pluginlib
+  CATKIN_DEPENDS roscpp message_runtime moveit_core tf kdl_parser pluginlib
   CFG_EXTRAS Exotica.cmake AddInitializer.cmake
 )
 

--- a/exotica/CMakeLists.txt
+++ b/exotica/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   message_generation
   moveit_core
+  moveit_ros_planning
   tf
   kdl_parser
   pluginlib
@@ -58,7 +59,7 @@ GenInitializers()
 catkin_package(
   INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR} include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS}
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS roscpp message_runtime moveit_core tf kdl_parser pluginlib
+  CATKIN_DEPENDS roscpp message_runtime moveit_core moveit_ros_planning tf kdl_parser pluginlib
   CFG_EXTRAS Exotica.cmake AddInitializer.cmake
 )
 

--- a/exotica/package.xml
+++ b/exotica/package.xml
@@ -20,6 +20,7 @@
   <depend>message_generation</depend>
   <depend>message_runtime</depend>
   <depend>moveit_core</depend>
+  <depend>moveit_ros_planning</depend>
   <depend>tf</depend>
   <depend>kdl_parser</depend>
   <depend>pluginlib</depend>

--- a/exotica/package.xml
+++ b/exotica/package.xml
@@ -19,7 +19,6 @@
   <depend>std_msgs</depend>
   <depend>message_generation</depend>
   <depend>message_runtime</depend>
-  <depend>moveit_ros_planning_interface</depend>
   <depend>moveit_core</depend>
   <depend>tf</depend>
   <depend>kdl_parser</depend>

--- a/pybind11_catkin/CMakeLists.txt
+++ b/pybind11_catkin/CMakeLists.txt
@@ -24,7 +24,8 @@ ExternalProject_Add(
 ExternalProject_Add_Step(
   pybind11 MOVEToShared
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${CATKIN_DEVEL_PREFIX}/share/cmake/pybind11 ${CATKIN_DEVEL_PREFIX}/share/pybind11/cmake
-  COMMAND ${CMAKE_COMMAND} -E copy ${CATKIN_DEVEL_PREFIX}/share/cmake/pybind11/pybind11Tools.cmake ${CATKIN_DEVEL_PREFIX}/share/cmake/pybind11/FindPythonLibsNew.cmake ${CATKIN_DEVEL_PREFIX}/share/pybind11_catkin/cmake
+  COMMAND ${CMAKE_COMMAND} -E copy ${CATKIN_DEVEL_PREFIX}/share/cmake/pybind11/pybind11Tools.cmake ${CATKIN_DEVEL_PREFIX}/share/pybind11_catkin/cmake
+  COMMAND ${CMAKE_COMMAND} -E copy ${CATKIN_DEVEL_PREFIX}/share/cmake/pybind11/FindPythonLibsNew.cmake ${CATKIN_DEVEL_PREFIX}/share/pybind11_catkin/cmake
   COMMAND ${CMAKE_COMMAND} -E remove_directory ${CATKIN_DEVEL_PREFIX}/share/cmake/
   DEPENDEES install
 )


### PR DESCRIPTION
Brings back continuous integration:

1. Now uses the packaged Eigen debian we recommend (we now require >3.2.7 for the Python bindings)
2. Fixes a PYTHONPATH bug that Travis recently introduced
3. Fixes dependency on ``moveit_ros_planning`` instead of ``moveit_ros_planning_interface`` [the latter had installation issues due to depending on the warehouse database]
4. Fixes a CMake error we hadn't caught without CI.

Still needs adding the Python tests and proper failure if tests fail. The Python tests won't work on Indigo as they all segfault due to an upstream roscomm issue.