### PR TITLE
Server simplification

### DIFF
--- a/examples/exotica_examples/CMakeLists.txt
+++ b/examples/exotica_examples/CMakeLists.txt
@@ -33,6 +33,9 @@ target_link_libraries(XMLInitialization ${catkin_LIBRARIES})
 add_executable(PlannerDemo src/planner.cpp)
 target_link_libraries(PlannerDemo ${catkin_LIBRARIES})
 
+add_executable(IK src/ik_minimal.cpp)
+target_link_libraries(IK ${catkin_LIBRARIES})
+
 install(TARGETS ManualInitialization GenericInitialization XMLInitialization PlannerDemo ExoticaCore
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/examples/exotica_examples/resources/aico_solver_demo_eight.xml
+++ b/examples/exotica_examples/resources/aico_solver_demo_eight.xml
@@ -21,7 +21,7 @@
 
     <Maps>
       <EffFrame Name="Frame">
-        <Scene>MyScene</Scene>
+        <Scene>AICOSolverDemoScene</Scene>
         <EndEffector>
             <Frame Link="lwr_arm_6_link" LinkOffset="0 0 0.2 0.7071067811865476 -4.3297802811774664e-17  0.7071067811865475 4.3297802811774664e-17" BaseOffset="0.6 -0.1 0.5 0 0 0 1" />
         </EndEffector>

--- a/examples/exotica_examples/src/core.cpp
+++ b/examples/exotica_examples/src/core.cpp
@@ -36,11 +36,6 @@ using namespace exotica;
 
 int main(int argc, char **argv)
 {
-    ros::init(argc, argv, "ExoticaCoreExampleNode");
-    ROS_INFO_STREAM("Started");
     ROS_INFO_STREAM("Exotica version: "<<exotica::Version);
     Setup::printSupportedClasses();
-    ROS_INFO_STREAM("Waiting");
-    ros::spin();
-    Setup::Instance().reset();
 }

--- a/examples/exotica_examples/src/generic.cpp
+++ b/examples/exotica_examples/src/generic.cpp
@@ -36,7 +36,7 @@ using namespace exotica;
 
 void run()
 {
-    ros::NodeHandle nhg_;
+    Server::InitRos(std::shared_ptr<ros::NodeHandle>(new ros::NodeHandle("~")));
 
     // Scene using joint group 'arm'
     Initializer scene("Scene",{{"Name",std::string("MyScene")},{"JointGroup",std::string("arm")}});

--- a/examples/exotica_examples/src/ik_minimal.cpp
+++ b/examples/exotica_examples/src/ik_minimal.cpp
@@ -1,0 +1,101 @@
+/*
+ *      Author: Vladimir Ivan
+ *
+ * Copyright (c) 2017, University Of Edinburgh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of  nor the names of its contributors may be used to
+ *    endorse or promote products derived from this software without specific
+ *    prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <exotica/Exotica.h>
+#include <exotica/Problems/UnconstrainedEndPoseProblem.h>
+#include <thread>
+#include <chrono>
+
+using namespace exotica;
+
+void run()
+{
+
+    Initializer solver, problem;
+
+    std::string file_name = ros::package::getPath("exotica_examples")+"/resources/ik_solver_demo.xml";
+
+    XMLLoader::load(file_name, solver, problem);
+
+    HIGHLIGHT_NAMED("XMLnode","Loaded from XML");
+
+    UnconstrainedEndPoseProblemInitializer problem_init(problem);
+    problem_init.PlanningScene.addProperty( Property("URDF", false, boost::any(ros::package::getPath("exotica_examples")+"/resources/lwr_simplified.urdf")));
+    problem_init.PlanningScene.addProperty( Property("SRDF", false, boost::any(ros::package::getPath("exotica_examples")+"/resources/lwr_simplified.srdf")));
+
+    PlanningProblem_ptr any_problem = Setup::createProblem(problem_init);
+    MotionSolver_ptr any_solver = Setup::createSolver(solver);
+
+    // Assign the problem to the solver
+    any_solver->specifyProblem(any_problem);
+    UnconstrainedEndPoseProblem_ptr my_problem = std::static_pointer_cast<UnconstrainedEndPoseProblem>(any_problem);
+
+    // Create the initial configuration
+    Eigen::VectorXd q = Eigen::VectorXd::Zero(my_problem->N);
+    Eigen::MatrixXd solution;
+
+    my_problem->qNominal = q;
+
+    ROS_INFO_STREAM("Calling solve() in an infinite loop");
+
+    double t = 0.0;
+    double dt = 1.0/20.0;
+
+    while (true)
+    {
+        // Update the goal if necessary
+        // e.g. figure eight
+        t += dt;
+        my_problem->y = {0.6,
+                -0.1 + sin(t * 2.0 * M_PI * 0.5) * 0.1,
+                0.5 + sin(t * M_PI * 0.5) * 0.2 ,0 ,0 ,0};
+
+        // Solve the problem using the IK solver
+        my_problem->setStartState(q);
+        any_solver->Solve(solution);
+
+        HIGHLIGHT("Solution ["<<solution<<"]");
+        q = solution.row(0);
+
+        my_problem->Update(q);
+
+        std::this_thread::sleep_for(std::chrono::duration<double>(dt));
+    }
+}
+
+int main(int argc, char **argv)
+{
+    ROS_INFO_STREAM("Started");
+
+    // Run demo code
+    run();
+}

--- a/examples/exotica_examples/src/manual.cpp
+++ b/examples/exotica_examples/src/manual.cpp
@@ -40,6 +40,8 @@ using namespace exotica;
 
 void run()
 {
+    Server::InitRos(std::shared_ptr<ros::NodeHandle>(new ros::NodeHandle("~")));
+
     // Scene using joint group 'arm'
     SceneInitializer scene("MyScene","arm");
     // End-effector task map with two position frames

--- a/examples/exotica_examples/src/planner.cpp
+++ b/examples/exotica_examples/src/planner.cpp
@@ -38,15 +38,14 @@ using namespace exotica;
 
 void run()
 {
-    ros::NodeHandle nhg_;
-    ros::NodeHandle nh_("~");
+    Server::InitRos(std::shared_ptr<ros::NodeHandle>(new ros::NodeHandle("~")));
 
     Initializer solver, problem;
 
     std::string file_name, solver_name, problem_name;
-    nh_.getParam("ConfigurationFile",file_name);
-    nh_.getParam("Solver",solver_name);
-    nh_.getParam("Problem",problem_name);
+    Server::getParam("ConfigurationFile",file_name);
+    Server::getParam("Solver",solver_name);
+    Server::getParam("Problem",problem_name);
 
     XMLLoader::load(file_name,solver, problem, solver_name, problem_name);
 

--- a/examples/exotica_examples/src/xml.cpp
+++ b/examples/exotica_examples/src/xml.cpp
@@ -37,12 +37,12 @@ using namespace exotica;
 
 void run()
 {
-    ros::NodeHandle nh_("~");
+    Server::InitRos(std::shared_ptr<ros::NodeHandle>(new ros::NodeHandle("~")));
 
     Initializer solver, problem;
 
     std::string file_name;
-    nh_.getParam("ConfigurationFile",file_name);
+    Server::getParam("ConfigurationFile",file_name);
 
     XMLLoader::load(file_name,solver, problem);
 

--- a/exotations/solvers/aico/include/aico/AICOsolver.h
+++ b/exotations/solvers/aico/include/aico/AICOsolver.h
@@ -144,7 +144,7 @@ namespace exotica
 
       std::map<std::string, std::pair<int, int> > taskIndex;
       Eigen::VectorXi dim; //!< Task dimension
-      ros::Duration planning_time_;
+      double planning_time_;
 
     protected:
 

--- a/exotations/solvers/ik_solver/include/ik_solver/IKSolver.h
+++ b/exotations/solvers/ik_solver/include/ik_solver/IKSolver.h
@@ -62,7 +62,7 @@ namespace exotica
       Eigen::MatrixXd PseudoInverse(Eigen::MatrixXdRefConst J);
 
       double error;
-      ros::Duration planning_time_;
+      double planning_time_;
 
       int getMaxIteration();
       int getLastIteration();

--- a/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
+++ b/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
@@ -32,6 +32,7 @@
  */
 
 #include "ik_solver/IKSolver.h"
+#include <chrono>
 
 #include <lapack/cblas.h>
 #include "f2c.h"
@@ -133,7 +134,7 @@ namespace exotica
         if(!prob_) throw_named("Solver has not been initialized!");
         Eigen::VectorXd q0 = prob_->applyStartState();
 
-        ros::Time start = ros::Time::now();
+        auto start = std::chrono::high_resolution_clock::now();
         if (prob_->N != q0.rows()) throw_named("Wrong size q0 size=" << q0.rows() << ", required size="<< prob_->N);
 
         bool UseNullspace = prob_->qNominal.rows()==prob_->N;
@@ -181,7 +182,7 @@ namespace exotica
 
         solution.row(0) = q;
 
-        planning_time_ = ros::Duration(ros::Time::now() - start);
+        planning_time_ = std::chrono::duration_cast<std::chrono::duration<double>>(std::chrono::high_resolution_clock::now() - start).count();
     }
 
     Eigen::MatrixXd IKsolver::PseudoInverse(Eigen::MatrixXdRefConst J)

--- a/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLBaseStateSpace.h
+++ b/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLBaseStateSpace.h
@@ -39,6 +39,7 @@
 #include <ompl/base/StateValidityChecker.h>
 #include <ompl/base/SpaceInformation.h>
 #include <ompl/base/ProjectionEvaluator.h>
+#include <ompl_imp_solver/OMPLImplementationInitializer.h>
 
 namespace ob = ompl::base;
 namespace exotica
@@ -47,7 +48,7 @@ namespace exotica
   class OMPLBaseStateSpace: public ompl::base::CompoundStateSpace
   {
     public:
-      OMPLBaseStateSpace(unsigned int dim, SamplingProblem_ptr &prob);
+      OMPLBaseStateSpace(unsigned int dim, SamplingProblem_ptr &prob, OMPLImplementationInitializer init);
 
       virtual void ExoticaToOMPLState(const Eigen::VectorXd &q,
           ompl::base::State *state) const = 0;
@@ -64,15 +65,15 @@ namespace exotica
   {
     public:
       OMPLStateValidityChecker(const ob::SpaceInformationPtr &si,
-          const SamplingProblem_ptr &prob);
+          const SamplingProblem_ptr &prob, OMPLImplementationInitializer init);
 
       virtual bool isValid(const ompl::base::State *state) const;
 
       virtual bool isValid(const ompl::base::State *state, double &dist) const;
     protected:
       SamplingProblem_ptr prob_;
-      EParam<std_msgs::Float64> margin_;
-      EParam<std_msgs::Bool> self_collision_;
+      double margin_;
+      bool self_collision_;
   };
 
 } /* namespace exotica */

--- a/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLImpSolver.h
+++ b/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLImpSolver.h
@@ -111,6 +111,8 @@ namespace exotica
       double margin_;
       Eigen::VectorXd qT_;
       int min_traj_length_;
+
+      OMPLImplementationInitializer init_;
     private:
       BASE_TYPE BaseType;
       double init_margin_;

--- a/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLRNStateSpace.h
+++ b/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLRNStateSpace.h
@@ -62,7 +62,7 @@ namespace exotica
             return *as<ob::RealVectorStateSpace::StateType>(0);
           }
       };
-      OMPLRNStateSpace(unsigned int dim, SamplingProblem_ptr &prob);
+      OMPLRNStateSpace(unsigned int dim, SamplingProblem_ptr &prob, OMPLImplementationInitializer init);
 
       virtual ompl::base::StateSamplerPtr allocDefaultStateSampler() const;
       virtual void ExoticaToOMPLState(const Eigen::VectorXd &q,

--- a/exotations/solvers/ompl_imp_solver/init/OMPLImplementation.in
+++ b/exotations/solvers/ompl_imp_solver/init/OMPLImplementation.in
@@ -3,3 +3,7 @@ Optional std::string Algorithm = "RRTConnect";
 Optional std::string SamplingSpace = "ConfigurationSpace";
 Optional int MaxGoalSamplingAttempts = 500;
 Optional double Timeout = 60.0;
+Optional bool SelfCollisionCheck = false;
+Optional bool UseGoalBias = false;
+Optional double GoalBias = 0.5;
+Optional Eigen::VectorXd ImportanceWeights = Eigen::VectorXd();

--- a/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLBaseStateSpace.cpp
+++ b/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLBaseStateSpace.cpp
@@ -35,34 +35,20 @@
 
 namespace exotica
 {
-  OMPLBaseStateSpace::OMPLBaseStateSpace(unsigned int dim, SamplingProblem_ptr &prob)
+  OMPLBaseStateSpace::OMPLBaseStateSpace(unsigned int dim, SamplingProblem_ptr &prob, OMPLImplementationInitializer init)
       : ob::CompoundStateSpace(), prob_(prob)
   {
   }
 
-  OMPLStateValidityChecker::OMPLStateValidityChecker(const ob::SpaceInformationPtr &si, const SamplingProblem_ptr &prob)
+  OMPLStateValidityChecker::OMPLStateValidityChecker(const ob::SpaceInformationPtr &si, const SamplingProblem_ptr &prob, OMPLImplementationInitializer init)
       : ob::StateValidityChecker(si), prob_(prob)
   {
     Server_ptr server = Server::Instance();
-    if (server->hasParam(server->getName() + "/SafetyMargin"))
-      server->getParam(server->getName() + "/SafetyMargin", margin_);
-    else
-    {
-      margin_.reset(new std_msgs::Float64());
-      margin_->data = 0.0;
-      server->setParam(server->getName() + "/SafetyMargin", margin_);
-    }
-    if (server->hasParam(server->getName() + "/SelfCollisionCheck"))
-      server->getParam(server->getName() + "/SelfCollisionCheck", self_collision_);
-    else
-    {
-      self_collision_.reset(new std_msgs::Bool());
-      self_collision_->data = false;
-      server->setParam(server->getName() + "/SelfCollisionCheck", self_collision_);
-    }
 
-    HIGHLIGHT_NAMED("OMPLStateValidityChecker",
-        "Safety Margin: " << margin_->data);
+    margin_ = init.Margin;
+    self_collision_ = init.SelfCollisionCheck;
+
+    HIGHLIGHT_NAMED("OMPLStateValidityChecker", "Safety Margin: " << margin_);
   }
 
   bool OMPLStateValidityChecker::isValid(const ompl::base::State *state) const
@@ -84,7 +70,7 @@ namespace exotica
 #endif
 
     prob_->Update(q);
-    if (!prob_->getScene()->getCollisionScene()->isStateValid(self_collision_->data, margin_->data))
+    if (!prob_->getScene()->getCollisionScene()->isStateValid(self_collision_, margin_))
     {
       dist = -1;
       return false;

--- a/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLImpSolver.cpp
+++ b/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLImpSolver.cpp
@@ -33,6 +33,7 @@
 
 #include "ompl_imp_solver/OMPLImpSolver.h"
 #include <pluginlib/class_list_macros.h>
+#include <chrono>
 
 #include <ompl/geometric/planners/rrt/RRT.h>
 #include <ompl/geometric/planners/rrt/pRRT.h>
@@ -118,7 +119,7 @@ namespace exotica
 
   bool OMPLImpSolver::solve(Eigen::VectorXdRefConst &x0, Eigen::MatrixXd &sol)
   {
-    ros::Time startTime = ros::Time::now();
+    auto startTime = std::chrono::high_resolution_clock::now();
     finishedSolving_ = false;
     ompl::base::ScopedState<> ompl_start_state(state_space_);
     state_space_->as<OMPLBaseStateSpace>()->ExoticaToOMPLState(x0, ompl_start_state.get());
@@ -135,9 +136,9 @@ namespace exotica
       finishedSolving_ = true;
 
       if (!ompl_simple_setup_->haveSolutionPath()) return false;
-      planning_time_ = ros::Time::now() - startTime;
+      planning_time_ = std::chrono::duration_cast<std::chrono::duration<double>>(std::chrono::high_resolution_clock::now() - startTime).count();
       getSimplifiedPath(ompl_simple_setup_->getSolutionPath(), sol, ptc);
-      planning_time_ = ros::Time::now() - startTime;
+      planning_time_ = std::chrono::duration_cast<std::chrono::duration<double>>(std::chrono::high_resolution_clock::now() - startTime).count();
       postSolve();
       margin_ = init_margin_;
       prob_->Update(Eigen::VectorXd(sol.row(sol.rows() - 1)));
@@ -147,7 +148,7 @@ namespace exotica
     else
     {
       finishedSolving_ = true;
-      planning_time_ = ros::Time::now() - startTime;
+      planning_time_ = std::chrono::duration_cast<std::chrono::duration<double>>(std::chrono::high_resolution_clock::now() - startTime).count();
       postSolve();
       return false;
     }
@@ -167,7 +168,7 @@ namespace exotica
 
   void OMPLImpSolver::getSimplifiedPath(og::PathGeometric &pg, Eigen::MatrixXd & traj, ob::PlannerTerminationCondition &ptc)
   {
-    ros::Time start = ros::Time::now();
+    auto start = std::chrono::high_resolution_clock::now();
 
     og::PathSimplifierPtr psf_ = ompl_simple_setup_->getPathSimplifier();
     const ob::SpaceInformationPtr &si = ompl_simple_setup_->getSpaceInformation();
@@ -203,7 +204,7 @@ namespace exotica
     //  unsigned int length = 50;
     pg.interpolate(length);
     convertPath(pg, traj);
-    HIGHLIGHT("Trajectory simplification took "<<ros::Duration(ros::Time::now()-start).toSec()<<" sec. Trajectory length after interpolation = "<<length);
+    HIGHLIGHT("Trajectory simplification took "<<std::chrono::duration_cast<std::chrono::duration<double>>(std::chrono::high_resolution_clock::now() - start).count()<<" sec. Trajectory length after interpolation = "<<length);
   }
 
   ompl::base::GoalPtr OMPLImpSolver::constructGoal()

--- a/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLImpSolver.cpp
+++ b/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLImpSolver.cpp
@@ -69,11 +69,11 @@ namespace exotica
 
   void OMPLImpSolver::initialiseSolver(Initializer& init)
   {
-      OMPLImplementationInitializer prop(init);
-      range_ = prop.Range;
-      if(prop.Algorithm!="")
+      init_ = OMPLImplementationInitializer(init);
+      range_ = init_.Range;
+      if(init_.Algorithm!="")
       {
-        algorithm_ = "geometric::"+prop.Algorithm;
+        algorithm_ = "geometric::"+init_.Algorithm;
       }
       object_name_=algorithm_;
 
@@ -88,8 +88,8 @@ namespace exotica
         for (auto &it : known_algorithms_)
           ERROR(it.first);
       }
-      margin_ = prop.Margin;
-      timeout_ = prop.Timeout;
+      margin_ = init_.Margin;
+      timeout_ = init_.Timeout;
   }
 
   void OMPLImpSolver::specifyProblem(const SamplingProblem_ptr &prob)
@@ -97,12 +97,12 @@ namespace exotica
     prob_ = prob;
     BaseType = prob_->getScene()->getBaseType();
     if (BaseType == BASE_TYPE::FIXED)
-      state_space_.reset(new OMPLRNStateSpace(prob_->getSpaceDim(), prob_));
+      state_space_.reset(new OMPLRNStateSpace(prob_->getSpaceDim(), prob_, init_));
     else if (BaseType == BASE_TYPE::FLOATING)
-      state_space_.reset(new OMPLSE3RNStateSpace(prob_->getSpaceDim() - 6, prob_));
+      state_space_.reset(new OMPLSE3RNStateSpace(prob_->getSpaceDim() - 6, prob_, init_));
 
     ompl_simple_setup_.reset(new og::SimpleSetup(state_space_));
-    ompl_simple_setup_->setStateValidityChecker(ob::StateValidityCheckerPtr(new OMPLStateValidityChecker(ompl_simple_setup_->getSpaceInformation(), prob_)));
+    ompl_simple_setup_->setStateValidityChecker(ob::StateValidityCheckerPtr(new OMPLStateValidityChecker(ompl_simple_setup_->getSpaceInformation(), prob_, init_)));
     ompl_simple_setup_->setPlannerAllocator(boost::bind(known_algorithms_[algorithm_], _1, "Exotica_" + algorithm_));
 
     std::vector<int> project_vars = { 0, 1 };

--- a/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLRNStateSpace.cpp
+++ b/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLRNStateSpace.cpp
@@ -35,8 +35,8 @@
 
 namespace exotica
 {
-  OMPLRNStateSpace::OMPLRNStateSpace(unsigned int dim, SamplingProblem_ptr &prob)
-      : OMPLBaseStateSpace(dim, prob)
+  OMPLRNStateSpace::OMPLRNStateSpace(unsigned int dim, SamplingProblem_ptr &prob, OMPLImplementationInitializer init)
+      : OMPLBaseStateSpace(dim, prob, init)
   {
     setName("OMPLRNStateSpace");
     addSubspace(

--- a/exotations/solvers/ompl_solver/include/ompl_solver/OMPLBaseSolver.h
+++ b/exotations/solvers/ompl_solver/include/ompl_solver/OMPLBaseSolver.h
@@ -147,7 +147,7 @@ namespace exotica
       /// \brief  Projection components
       std::vector<std::string> projection_components_;
 
-      ros::Duration planning_time_;
+      double planning_time_;
 
   };
   typedef std::shared_ptr<exotica::OMPLBaseSolver> OMPLBaseSolver_ptr;

--- a/exotations/solvers/ompl_solver/include/ompl_solver/OMPLsolver.h
+++ b/exotations/solvers/ompl_solver/include/ompl_solver/OMPLsolver.h
@@ -94,12 +94,6 @@ namespace exotica
 
       OMPLBaseSolver_ptr base_solver_;
 
-      /// \brief  Indicate if trajectory smoother is required
-      EParam<std_msgs::Bool> smooth_;
-      /// \brief  Maximum step
-      EParam<std_msgs::String> range_;
-      EParam<std_msgs::String> solver_;
-
       OMPLsolverInitializer parameters_;
   };
 

--- a/exotations/solvers/ompl_solver/src/OMPLBaseSolver.cpp
+++ b/exotations/solvers/ompl_solver/src/OMPLBaseSolver.cpp
@@ -37,7 +37,7 @@ namespace exotica
 
   double OMPLBaseSolver::getPlanningTime()
   {
-    return planning_time_.toSec();
+    return planning_time_;
   }
 
   bool OMPLBaseSolver::preSolve()

--- a/exotations/task_maps/task_map/src/CoM.cpp
+++ b/exotations/task_maps/task_map/src/CoM.cpp
@@ -153,7 +153,7 @@ namespace exotica
             }
         }
 
-        InitDebug();
+        if(debug_) InitDebug();
     }
 
     void CoM::assignScene(Scene_ptr scene)

--- a/exotations/task_maps/task_map/src/CoM.cpp
+++ b/exotations/task_maps/task_map/src/CoM.cpp
@@ -189,7 +189,7 @@ namespace exotica
 
         com_marker_.header.frame_id = COM_marker_.header.frame_id = scene_->getRootName();
 
-        com_pub_ = Server::Instance()->advertise<visualization_msgs::Marker>(object_name_ + "coms_marker", 1);
-        COM_pub_ = Server::Instance()->advertise<visualization_msgs::Marker>(object_name_ + "COM_marker", 1);
+        com_pub_ = Server::advertise<visualization_msgs::Marker>(object_name_ + "coms_marker", 1);
+        COM_pub_ = Server::advertise<visualization_msgs::Marker>(object_name_ + "COM_marker", 1);
     }
 }

--- a/exotations/task_maps/task_map/src/IMesh.cpp
+++ b/exotations/task_maps/task_map/src/IMesh.cpp
@@ -148,8 +148,11 @@ namespace exotica
 
     void IMesh::Instantiate(IMeshInitializer& init)
     {
-        initDebug(init.ReferenceFrame);
         Debug = init.Debug;
+        if(Debug)
+        {
+            initDebug(init.ReferenceFrame);
+        }
         eff_size_ = Frames.size();
         weights_.setOnes(eff_size_, eff_size_);
         if(init.Weights.rows()==eff_size_*eff_size_)

--- a/exotations/task_maps/task_map/src/IMesh.cpp
+++ b/exotations/task_maps/task_map/src/IMesh.cpp
@@ -142,7 +142,7 @@ namespace exotica
     {
         imesh_mark_.header.frame_id = ref;
         imesh_mark_.ns = getObjectName();
-        imesh_mark_pub_ = Server::Instance()->advertise<visualization_msgs::Marker>(ns_ +"/InteractionMesh", 1, true);
+        imesh_mark_pub_ = Server::advertise<visualization_msgs::Marker>(ns_ +"/InteractionMesh", 1, true);
         if(debug_) HIGHLIGHT("InteractionMesh connectivity is published on ROS topic "<<imesh_mark_pub_.getTopic()<<", in reference frame "<<ref);
     }
 

--- a/exotations/task_maps/task_map/src/SphereCollision.cpp
+++ b/exotations/task_maps/task_map/src/SphereCollision.cpp
@@ -67,7 +67,7 @@ namespace exotica
             }
         }
         debug = init.Debug;
-        debug_pub = Server::Instance()->advertise<visualization_msgs::MarkerArray>(ns_ +"/CollisionSpheres", 1, true);
+        debug_pub = Server::advertise<visualization_msgs::MarkerArray>(ns_ +"/CollisionSpheres", 1, true);
     }
 
     double SphereCollision::distance(const KDL::Frame& effA, const KDL::Frame& effB, double rA, double rB)

--- a/exotations/task_maps/task_map/src/SphereCollision.cpp
+++ b/exotations/task_maps/task_map/src/SphereCollision.cpp
@@ -67,7 +67,10 @@ namespace exotica
             }
         }
         debug = init.Debug;
-        debug_pub = Server::advertise<visualization_msgs::MarkerArray>(ns_ +"/CollisionSpheres", 1, true);
+        if(debug)
+        {
+            debug_pub = Server::advertise<visualization_msgs::MarkerArray>(ns_ +"/CollisionSpheres", 1, true);
+        }
     }
 
     double SphereCollision::distance(const KDL::Frame& effA, const KDL::Frame& effB, double rA, double rB)

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -44,7 +44,7 @@
 #include <set>
 #include <exotica/Tools.h>
 
-#include <tf/transform_broadcaster.h>
+#include <exotica/Server.h>
 #include <tf_conversions/tf_kdl.h>
 
 #define ROOT  -1     //!< The value of the parent for the root segment
@@ -234,7 +234,6 @@ namespace exotica
             std::shared_ptr<KinematicResponse> Solution;
             KinematicRequestFlags Flags;
 
-            tf::TransformBroadcaster debugTF;
             std::vector<tf::StampedTransform> debugTree;
             std::vector<tf::StampedTransform> debugFrames;
     };

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -215,7 +215,6 @@ namespace exotica
 
       std::string scene_name_;
       BASE_TYPE BaseType;
-      EParam<std_msgs::Bool> drake_full_body_;;
 
   };
 

--- a/exotica/init/Scene.in
+++ b/exotica/init/Scene.in
@@ -1,3 +1,5 @@
 extend <exotica/Object>
 Required std::string JointGroup;
 Optional std::string RobotDescription = "robot_description";
+Optional std::string URDF = "";
+Optional std::string SRDF = "";

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -308,7 +308,7 @@ void KinematicTree::publishFrames()
         if(i>0) debugTree[i-1] = tf::StampedTransform(T, ros::Time::now(), tf::resolve("exotica",getRootName()), tf::resolve("exotica", element->Segment.getName()));
         i++;
     }
-    debugTF.sendTransform(debugTree);
+    Server::sendTransform(debugTree);
     i = 0;
     for(KinematicFrame&  frame : Solution->Frame)
     {
@@ -319,7 +319,7 @@ void KinematicTree::publishFrames()
         debugFrames[i*2+1] = tf::StampedTransform(T, ros::Time::now(), tf::resolve("exotica","Frame"+std::to_string(i)+"B"+frame.FrameB->Segment.getName()), tf::resolve("exotica","Frame"+std::to_string(i)+"A"+frame.FrameA->Segment.getName()));
         i++;
     }
-    debugTF.sendTransform(debugFrames);
+    Server::sendTransform(debugFrames);
 }
 
 void KinematicTree::UpdateFK()

--- a/exotica_python/CMakeLists.txt
+++ b/exotica_python/CMakeLists.txt
@@ -20,5 +20,5 @@ pybind_add_module(_pyexotica MODULE src/Exotica.cpp)
 catkin_python_setup()
 
 install(TARGETS _pyexotica LIBRARY DESTINATION ${CATKIN_GLOBAL_PYTHON_DESTINATION})
-catkin_install_python(PROGRAMS scripts/example_aico.py scripts/example_ompl.py scripts/example_ik.py DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+catkin_install_python(PROGRAMS scripts/example_aico.py scripts/example_ompl.py scripts/example_ik.py scripts/example_ik_noros.py DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 install(DIRECTORY launch/ DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch)

--- a/exotica_python/scripts/example_aico.py
+++ b/exotica_python/scripts/example_aico.py
@@ -9,6 +9,7 @@ import math
 def figureEight(t):
     return array([0.0, math.sin(t * 2.0 * math.pi * 0.5) * 0.1, math.sin(t * math.pi * 0.5) * 0.2, 0.0, 0.0, 0.0])
 
+exo.Setup.initRos()
 (sol, prob)=exo.Initializers.loadXMLFull(exo.Setup.getPackagePath('exotica_examples')+'/resources/aico_solver_demo_eight.xml')
 problem = exo.Setup.createProblem(prob)
 solver = exo.Setup.createSolver(sol)

--- a/exotica_python/scripts/example_aico_noros.py
+++ b/exotica_python/scripts/example_aico_noros.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+import pyexotica as exo
+from numpy import array
+from numpy import matrix
+from pyexotica.publish_trajectory import *
+import math
+
+def figureEight(t):
+    return array([0.0, math.sin(t * 2.0 * math.pi * 0.5) * 0.1, math.sin(t * math.pi * 0.5) * 0.2, 0.0, 0.0, 0.0])
+
+(sol, prob)=exo.Initializers.loadXMLFull(exo.Setup.getPackagePath('exotica_examples')+'/resources/aico_solver_demo_eight.xml')
+# Set UDRF and SRDF file paths (overrides using robot_description)
+prob[1]['PlanningScene'][0][1]['URDF'] = exo.Setup.getPackagePath('exotica_examples')+'/resources/lwr_simplified.urdf'
+prob[1]['PlanningScene'][0][1]['SRDF'] = exo.Setup.getPackagePath('exotica_examples')+'/resources/lwr_simplified.srdf'
+
+problem = exo.Setup.createProblem(prob)
+solver = exo.Setup.createSolver(sol)
+solver.specifyProblem(problem)
+
+for t in range(0,problem.T):
+    if t<problem.T/5:
+        problem.setRho('Frame',0.0,t)
+    else:
+        problem.setRho('Frame',1e5,t)
+        problem.setGoal('Frame',figureEight(t*problem.tau),t)
+
+solution = solver.solve()
+
+plot(solution)
+
+

--- a/exotica_python/scripts/example_ik.py
+++ b/exotica_python/scripts/example_ik.py
@@ -10,6 +10,7 @@ from time import sleep
 def figureEight(t):
     return array([0.6, -0.1 + math.sin(t * 2.0 * math.pi * 0.5) * 0.1, 0.5 + math.sin(t * math.pi * 0.5) * 0.2, 0, 0, 0])
 
+exo.Setup.initRos()
 (sol, prob)=exo.Initializers.loadXMLFull(exo.Setup.getPackagePath('exotica_examples')+'/resources/ik_solver_demo.xml')
 problem = exo.Setup.createProblem(prob)
 solver = exo.Setup.createSolver(sol)

--- a/exotica_python/scripts/example_ik_noros.py
+++ b/exotica_python/scripts/example_ik_noros.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+print('Start')
+import pyexotica as exo
+from numpy import array
+from numpy import matrix
+import math
+from time import sleep
+
+def figureEight(t):
+    return array([0.6, -0.1 + math.sin(t * 2.0 * math.pi * 0.5) * 0.1, 0.5 + math.sin(t * math.pi * 0.5) * 0.2, 0, 0, 0])
+
+(sol, prob)=exo.Initializers.loadXMLFull(exo.Setup.getPackagePath('exotica_examples')+'/resources/ik_solver_demo.xml')
+# Set UDRF and SRDF file paths (overrides using robot_description)
+prob[1]['PlanningScene'][0][1]['URDF'] = exo.Setup.getPackagePath('exotica_examples')+'/resources/lwr_simplified.urdf'
+prob[1]['PlanningScene'][0][1]['SRDF'] = exo.Setup.getPackagePath('exotica_examples')+'/resources/lwr_simplified.srdf'
+
+problem = exo.Setup.createProblem(prob)
+solver = exo.Setup.createSolver(sol)
+solver.specifyProblem(problem)
+
+dt=1.0/20.0
+t=0.0
+q=array([0.0]*7)
+print('Publishing IK')
+while True:
+    problem.setGoal('Position',figureEight(t))
+    problem.startState = q
+    q = solver.solve()[0]
+    print(q)
+    sleep(dt)
+    t=t+dt
+

--- a/exotica_python/scripts/example_ompl.py
+++ b/exotica_python/scripts/example_ompl.py
@@ -5,7 +5,7 @@ from numpy import array
 from numpy import matrix
 from pyexotica.publish_trajectory import *
 
-
+exo.Setup.initRos()
 (sol, prob)=exo.Initializers.loadXMLFull(exo.Setup.getPackagePath('exotica_examples')+'/resources/ompl_solver_demo.xml')
 problem = exo.Setup.createProblem(prob)
 solver = exo.Setup.createSolver(sol)

--- a/exotica_python/scripts/example_ompl_noros.py
+++ b/exotica_python/scripts/example_ompl_noros.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+import pyexotica as exo
+from numpy import array
+from numpy import matrix
+from pyexotica.publish_trajectory import *
+
+(sol, prob)=exo.Initializers.loadXMLFull(exo.Setup.getPackagePath('exotica_examples')+'/resources/ompl_solver_demo.xml')
+# Set UDRF and SRDF file paths (overrides using robot_description)
+prob[1]['PlanningScene'][0][1]['URDF'] = exo.Setup.getPackagePath('exotica_examples')+'/resources/lwr_simplified.urdf'
+prob[1]['PlanningScene'][0][1]['SRDF'] = exo.Setup.getPackagePath('exotica_examples')+'/resources/lwr_simplified.srdf'
+
+problem = exo.Setup.createProblem(prob)
+solver = exo.Setup.createSolver(sol)
+solver.specifyProblem(problem)
+
+solution = solver.solve()
+
+plot(solution)

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -357,9 +357,6 @@ PYBIND11_MODULE(_pyexotica, module)
 
     module.doc() = "Exotica Python wrapper";
 
-    int argc = 0;
-    ros::init(argc, nullptr, "exotica_python_node");
-
     py::class_<Setup, std::unique_ptr<Setup, py::nodelete>> setup(module, "Setup");
     setup.def("__init__",[](Setup* instance){instance=Setup::Instance().get();});
     setup.def_static("getSolvers", &Setup::getSolvers);
@@ -371,6 +368,7 @@ PYBIND11_MODULE(_pyexotica, module)
     setup.def_static("printSupportedClasses",&Setup::printSupportedClasses);
     setup.def_static("getInitializers",&Setup::getInitializers, py::return_value_policy::copy);
     setup.def_static("getPackagePath",&ros::package::getPath);
+    setup.def_static("initRos",[](){int argc = 0; ros::init(argc, nullptr, "exotica_python_node"); Server::InitRos(std::shared_ptr<ros::NodeHandle>(new ros::NodeHandle("~")));});
 
     py::class_<Object, std::shared_ptr<Object>> object(module, "Object");
     object.def("getType", &Object::type, "Object type");


### PR DESCRIPTION
- Removed `EParam` and related methods.
- Makes creating a ROS node inside the server optional:
    - `Server::InitRos()` initializes an internal ros node. Use `isRos` to check if the method has been called.
    - `getParam`, `hasParam`, `advertise`, `sendTrasform` wrap ros methods and check if ROS has been initialized.
    - Robot model gets loaded from 'robot_description' only if ROS node has been initialized.
    - Examples running without roscore have been added.
- Robot model can be now loaded directly from a file:
    - Specify 'URDF' and 'SRDF' parameters for SceneInitializer to bypass ROS parameters.
    - Examples in c++ and python included.

Fixes #62 
