### PR TITLE
Simplify initialization

### DIFF
--- a/examples/exotica_examples/CMakeLists.txt
+++ b/examples/exotica_examples/CMakeLists.txt
@@ -36,7 +36,7 @@ target_link_libraries(PlannerDemo ${catkin_LIBRARIES})
 add_executable(IK src/ik_minimal.cpp)
 target_link_libraries(IK ${catkin_LIBRARIES})
 
-install(TARGETS ManualInitialization GenericInitialization XMLInitialization PlannerDemo ExoticaCore
+install(TARGETS ManualInitialization GenericInitialization XMLInitialization PlannerDemo ExoticaCore IK
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 

--- a/examples/exotica_examples/src/generic.cpp
+++ b/examples/exotica_examples/src/generic.cpp
@@ -47,7 +47,6 @@ void run()
     // End-effector task map with two position frames
     Initializer map("exotica/EffFrame",{
                         {"Name",std::string("Position")},
-                        {"Scene",std::string("MyScene")},
                         {"EndEffector",std::vector<Initializer>({
                              Initializer("Frame",{{"Link",std::string("lwr_arm_6_link")}, {"LinkOffset", Eigen::VectorTransform(0 ,0 ,0 ,0.7071067811865476, -4.3297802811774664e-17, 0.7071067811865475, 4.3297802811774664e-17)}}),
                          })}});

--- a/examples/exotica_examples/src/manual.cpp
+++ b/examples/exotica_examples/src/manual.cpp
@@ -45,7 +45,7 @@ void run()
     // Scene using joint group 'arm'
     SceneInitializer scene("MyScene", "arm", false, "", "{exotica}/resources/robots/lwr_simplified.urdf", "{exotica}/resources/robots/lwr_simplified.srdf");
     // End-effector task map with two position frames
-    EffFrameInitializer map("Position","MyScene",false,
+    EffFrameInitializer map("Position",false,
     {FrameInitializer("lwr_arm_6_link", Eigen::VectorTransform(0 ,0 ,0 ,0.7071067811865476, -4.3297802811774664e-17, 0.7071067811865475, 4.3297802811774664e-17))});
     // Create a task using the map above (goal will be specified later)
     Eigen::VectorXd W(7);

--- a/exotations/task_maps/task_map/tests/test_maps.cpp
+++ b/exotations/task_maps/task_map/tests/test_maps.cpp
@@ -124,7 +124,6 @@ void testJacobian(UnconstrainedEndPoseProblem_ptr problem, double eps = 1e-5)
 UnconstrainedEndPoseProblem_ptr setupProbelm(Initializer& map)
 {
     Initializer scene("Scene",{{"Name",std::string("MyScene")},{"JointGroup",std::string("arm")}});
-    map.addProperty(Property("Scene", true, std::string("MyScene")));
     Eigen::VectorXd W(3);W << 3,2,1;
     Initializer problem("exotica/UnconstrainedEndPoseProblem",{
                             {"Name",std::string("MyProblem")},

--- a/exotica/include/exotica/Loaders/XMLLoader.h
+++ b/exotica/include/exotica/Loaders/XMLLoader.h
@@ -2,6 +2,9 @@
 #define XMLLOADER_H
 
 #include <exotica/Property.h>
+#include <exotica/MotionSolver.h>
+#include <exotica/PlanningProblem.h>
+#include <exotica/Setup.h>
 
 namespace exotica
 {
@@ -29,6 +32,16 @@ public:
     static Initializer load(std::string file_name, bool parsePathAsXML=false)
     {
         return Instance()->loadXML(file_name, parsePathAsXML);
+    }
+
+    static std::shared_ptr<exotica::MotionSolver> loadSolver(const std::string& file_name)
+    {
+        Initializer solver, problem;
+        XMLLoader::load(file_name, solver, problem);
+        PlanningProblem_ptr any_problem = Setup::createProblem(problem);
+        MotionSolver_ptr any_solver = Setup::createSolver(solver);
+        any_solver->specifyProblem(any_problem);
+        return any_solver;
     }
 
 private:

--- a/exotica/init/TaskMap.in
+++ b/exotica/init/TaskMap.in
@@ -1,4 +1,3 @@
 include <exotica/FrameInitializer>
 extend <exotica/Object>
-Required std::string Scene;
 Optional std::vector<exotica::Initializer> EndEffector = std::vector<exotica::Initializer>(); # FrameInitializer

--- a/exotica/init/TaskSqrError.in
+++ b/exotica/init/TaskSqrError.in
@@ -1,3 +1,0 @@
-extend <exotica/TaskDefinition>
-Required double Rho;
-Optional Eigen::VectorXd Goal; // If unset, zero is used.

--- a/exotica/init/TaskTerminationCriterion.in
+++ b/exotica/init/TaskTerminationCriterion.in
@@ -1,2 +1,0 @@
-extend <exotica/TaskSqrError>
-Required double Threshold;

--- a/exotica/init/UnconstrainedEndPoseProblem.in
+++ b/exotica/init/UnconstrainedEndPoseProblem.in
@@ -2,3 +2,4 @@ extend <exotica/PlanningProblem>
 Optional Eigen::VectorXd W = Eigen::VectorXd();
 Optional Eigen::VectorXd Rho = Eigen::VectorXd();
 Optional Eigen::VectorXd Goal = Eigen::VectorXd();
+Optional Eigen::VectorXd NominalState = Eigen::VectorXd();

--- a/exotica/resources/configs/example.xml
+++ b/exotica/resources/configs/example.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+<ExampleConfig>
+
+<IKsolver Name="MySolver">
+  <MaxIt>100</MaxIt>
+  <MaxStep>0.1</MaxStep>
+  <Tolerance>1e-5</Tolerance>
+  <Alpha>1.0</Alpha>
+  <C>1e-3</C>
+</IKsolver>
+
+<UnconstrainedEndPoseProblem Name="ExampleProblem">
+  <PlanningScene>
+    <Scene>
+      <JointGroup>arm</JointGroup>
+      <URDF>{exotica}/resources/robots/lwr_simplified.urdf</URDF>
+      <SRDF>{exotica}/resources/robots/lwr_simplified.srdf</SRDF>
+    </Scene>
+  </PlanningScene>
+  <Maps>
+    <EffPosition Name="Position">
+      <EndEffector>
+          <Frame Link="lwr_arm_7_link" BaseOffset="0.5 0 0.5 0 0 0 1"/>
+      </EndEffector>
+    </EffPosition>
+  </Maps>
+  <W> 7 6 5 4 3 2 1 </W>
+  <StartState>0 0 0 0 0 0 0</StartState>
+  <NominalState>0 0 0 0 0 0 0</NominalState>
+</UnconstrainedEndPoseProblem>
+
+</ExampleConfig>

--- a/exotica/resources/configs/ik_solver_demo.xml
+++ b/exotica/resources/configs/ik_solver_demo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <IKSolverDemoConfig>
 
-  <IKsolver Name="MySolver">   <!-- Motion solver definition -->
+  <IKsolver Name="MySolver">
     <MaxIt>1</MaxIt>
     <MaxStep>0.1</MaxStep>
     <Tolerance>1e-5</Tolerance>
@@ -9,11 +9,10 @@
     <C>1e-3</C>
   </IKsolver>
 
-  <UnconstrainedEndPoseProblem Name="MyProblem"> <!-- Problem definition -->
+  <UnconstrainedEndPoseProblem Name="MyProblem">
 
     <PlanningScene>
-      <Scene Name="MyScene"> <!-- Kinematic scene -->
-        <PlanningMode>Optimization</PlanningMode>
+      <Scene>
         <JointGroup>arm</JointGroup>
         <URDF>{exotica}/resources/robots/lwr_simplified.urdf</URDF>
         <SRDF>{exotica}/resources/robots/lwr_simplified.srdf</SRDF>
@@ -22,15 +21,11 @@
     
     <Maps>
       <EffFrame Name="Position">
-        <Scene>MyScene</Scene>
         <EndEffector>
             <Frame Link="lwr_arm_6_link" LinkOffset="0 0 0 0.7071067811865476 -4.3297802811774664e-17  0.7071067811865475 4.3297802811774664e-17"/>
         </EndEffector>
       </EffFrame>
     </Maps>
-
-    <!-- Problem parameters: tolerance and per joint weighting -->
-
     <W> 7 6 5 4 3 2 1 </W>
   </UnconstrainedEndPoseProblem>
 

--- a/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
@@ -79,6 +79,8 @@ namespace exotica
         Phi = y;
         J = Eigen::MatrixXd(JN, N);
 
+        qNominal = init.NominalState;
+
         if(init.Rho.rows()>0 && init.Rho.rows()!=NumTasks) throw_named("Invalide size of Rho (" << init.Rho.rows() << ") expected: "<< NumTasks);
         if(init.Goal.rows()>0 && init.Goal.rows()!=PhiN) throw_named("Invalide size of Rho (" << init.Goal.rows() << ") expected: "<< PhiN);
 

--- a/exotica_python/CMakeLists.txt
+++ b/exotica_python/CMakeLists.txt
@@ -20,5 +20,13 @@ pybind_add_module(_pyexotica MODULE src/Exotica.cpp)
 catkin_python_setup()
 
 install(TARGETS _pyexotica LIBRARY DESTINATION ${CATKIN_GLOBAL_PYTHON_DESTINATION})
-catkin_install_python(PROGRAMS scripts/example_aico.py scripts/example_ompl.py scripts/example_ik.py scripts/example_ik_noros.py DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+catkin_install_python(PROGRAMS
+    scripts/example.py
+    scripts/example_aico.py
+    scripts/example_ompl.py
+    scripts/example_ik.py
+    scripts/example_ik_noros.py
+    scripts/example_aico_noros.py
+    scripts/example_ompl_noros.py
+      DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 install(DIRECTORY launch/ DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch)

--- a/exotica_python/scripts/example.py
+++ b/exotica_python/scripts/example.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+import pyexotica as exo
+solver=exo.Setup.loadSolver('{exotica}/resources/configs/example.xml')
+print(solver.solve())

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -369,6 +369,7 @@ PYBIND11_MODULE(_pyexotica, module)
     setup.def_static("getInitializers",&Setup::getInitializers, py::return_value_policy::copy);
     setup.def_static("getPackagePath",&ros::package::getPath);
     setup.def_static("initRos",[](){int argc = 0; ros::init(argc, nullptr, "exotica_python_node"); Server::InitRos(std::shared_ptr<ros::NodeHandle>(new ros::NodeHandle("~")));});
+    setup.def_static("loadSolver", &XMLLoader::loadSolver);
 
     py::module tools = module.def_submodule("Tools");
     tools.def("parsePath", &parsePath);


### PR DESCRIPTION
- Adds `NominalState` to the `UnconstrainedEndPoseProblemInitializer` (bugfix).
- Removes scene name from `TaskMap` and `Scene` initializers (depricated).
- Removes old unused initializers.
- Simplifies initialization and adds a minimal IK example using this (used in book chapter).