### PR TITLE
Clean up PlanningMode initialization parameter

### DIFF
--- a/exotica/resources/configs/aico_solver_demo.xml
+++ b/exotica/resources/configs/aico_solver_demo.xml
@@ -14,7 +14,6 @@
 
     <PlanningScene>
       <Scene Name="AICOSolverDemoScene">
-        <PlanningMode>Optimization</PlanningMode>
         <JointGroup>arm</JointGroup>
         <URDF>{exotica}/resources/robots/lwr_simplified.urdf</URDF>
         <SRDF>{exotica}/resources/robots/lwr_simplified.srdf</SRDF>

--- a/exotica/resources/configs/aico_solver_demo_eight.xml
+++ b/exotica/resources/configs/aico_solver_demo_eight.xml
@@ -14,7 +14,6 @@
 
     <PlanningScene>
       <Scene Name="AICOSolverDemoScene">
-        <PlanningMode>Optimization</PlanningMode>
         <JointGroup>arm</JointGroup>
         <URDF>{exotica}/resources/robots/lwr_simplified.urdf</URDF>
         <SRDF>{exotica}/resources/robots/lwr_simplified.srdf</SRDF>

--- a/exotica/resources/configs/ompl_solver_demo.xml
+++ b/exotica/resources/configs/ompl_solver_demo.xml
@@ -10,6 +10,7 @@
 
     <PlanningScene>
       <Scene Name="OMPLSolverDemoScene">
+        <!-- Computing distances is enabled by default, disable for a Sampling problem by setting the PlanningMode to speed up Scene updates -->
         <PlanningMode>Sampling</PlanningMode>
         <JointGroup>arm</JointGroup>
         <URDF>{exotica}/resources/robots/lwr_simplified.urdf</URDF>

--- a/exotica/tests/test_initializers.cpp
+++ b/exotica/tests/test_initializers.cpp
@@ -75,7 +75,7 @@ bool testGenericInit()
 
 bool testXMLInit()
 {
-    std::string XMLstring = "<IKSolverDemoConfig><IKsolver Name=\"MySolver\"><MaxIt>1</MaxIt><MaxStep>0.1</MaxStep><C>1e-3</C></IKsolver><UnconstrainedEndPoseProblem Name=\"MyProblem\"><PlanningScene><Scene Name=\"MyScene\"><PlanningMode>Optimization</PlanningMode><JointGroup>arm</JointGroup></Scene></PlanningScene><Maps><EffPosition Name=\"Position\"><Scene>MyScene</Scene><EndEffector><Frame Link=\"endeff\" /></EndEffector></EffPosition></Maps><W> 3 2 1 </W></UnconstrainedEndPoseProblem></IKSolverDemoConfig>";
+    std::string XMLstring = "<IKSolverDemoConfig><IKsolver Name=\"MySolver\"><MaxIt>1</MaxIt><MaxStep>0.1</MaxStep><C>1e-3</C></IKsolver><UnconstrainedEndPoseProblem Name=\"MyProblem\"><PlanningScene><Scene Name=\"MyScene\"><JointGroup>arm</JointGroup></Scene></PlanningScene><Maps><EffPosition Name=\"Position\"><Scene>MyScene</Scene><EndEffector><Frame Link=\"endeff\" /></EndEffector></EffPosition></Maps><W> 3 2 1 </W></UnconstrainedEndPoseProblem></IKSolverDemoConfig>";
     Initializer solver, problem;
     XMLLoader::load(XMLstring,solver, problem,"","",true);
     PlanningProblem_ptr any_problem = Setup::createProblem(problem);


### PR DESCRIPTION
- Remove PlanningMode=Optimization parameter as the default is to compute distances
- Add comment that setting PlanningMode=Sampling speeds up scene updates as distances are not computed