### PR TITLE
Collision and planning scene updates and fixes

### DIFF
--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -128,14 +128,19 @@ namespace exotica
       bool isStateValid(const Eigen::VectorXd &q);
 
       /**
-       * \brief	Get closest distance between robot link and anyother objects
+       * \brief Check for the closest distance in the planning scene including both self- and world-collisions
+       * @return The closest distance - negative values indicate penetration.
+       */
+      double getClosestDistance();
+
+      /**
+       * \brief	Get closest distance between robot link and any other objects
        * @param	link	Robot link
        * @param	self	Indicate if self collision check is required
        * @param	d		Closest distance
        * @param	p1		Closest distance point on the link
        * @param	p2		Closest distance point on the other object
        * @param	norm	Normal vector on robot link
-       * @return Indication of success
        */
       void getRobotDistance(const std::string & link, bool self, double & d,
           Eigen::Vector3d & p1, Eigen::Vector3d & p2, Eigen::Vector3d & norm,

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -277,8 +277,7 @@ namespace exotica
       ///	The collision scene
       CollisionScene_ptr collision_scene_;
 
-      ///	Visual debug
-      bool visual_debug_;
+      /// Visual debug
       ros::Publisher ps_pub_;
   };
   typedef std::shared_ptr<Scene> Scene_ptr;

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -236,7 +236,7 @@ namespace exotica
       std::string getName();
       virtual void Update(Eigen::VectorXdRefConst x);
       void setCollisionScene(const planning_scene::PlanningSceneConstPtr & scene);
-      void setCollisionScene( const moveit_msgs::PlanningSceneConstPtr & scene);
+      void setCollisionScene(const moveit_msgs::PlanningSceneConstPtr & scene);
       int getNumJoints();
       CollisionScene_ptr & getCollisionScene();
       std::string getRootName();

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -168,8 +168,13 @@ namespace exotica
         return fcl_robot_;
       }
 
-      void updateWorld(
-          const moveit_msgs::PlanningSceneWorldConstPtr & world);
+      /**
+       * @brief      Update the internal MoveIt planning scene from a
+       * moveit_msgs::PlanningSceneWorld
+       *
+       * @param[in]  world  moveit_msgs::PlanningSceneWorld
+       */
+      void updateWorld(const moveit_msgs::PlanningSceneWorldConstPtr& world);
       void getCollisionLinkTranslation(const std::string & name,
           Eigen::Vector3d & translation);
       void getWorldObjectTranslation(const std::string & name,

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -123,10 +123,9 @@ namespace exotica
       /**
        * \brief	Check if the whole robot is valid given a configuration
        * @param	q		The configuration to check
-       * @param	self	Indicate if self collision check is required
        * @return True, if the state is collision free.
        */
-      bool isStateValid(const Eigen::VectorXd &q, bool self = true);
+      bool isStateValid(const Eigen::VectorXd &q);
 
       /**
        * \brief	Get closest distance between robot link and anyother objects

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -288,13 +288,21 @@ namespace exotica
   double CollisionScene::getClosestDistance() {
     collision_detection::CollisionRequest req;
     collision_detection::CollisionResult res;
+    double selfCollisionDistance, environmentCollisionDistance;
 
-    // Check for both self- and world-collisions
     req.contacts = false;
     req.distance = true;
-    ps_->checkCollision(req, res, getCurrentState(), *acm_);
+    ps_->checkSelfCollision(req, res, ps_->getCurrentState(), *acm_);
+    selfCollisionDistance = res.distance;
 
-    return res.distance;
+    res.clear();
+    ps_->getCollisionWorld()->checkRobotCollision(
+        req, res, *ps_->getCollisionRobot(), ps_->getCurrentState());
+    environmentCollisionDistance = res.distance;
+
+    return (selfCollisionDistance < environmentCollisionDistance)
+               ? selfCollisionDistance
+               : environmentCollisionDistance;
   }
 
   void CollisionScene::getRobotDistance(const std::string & link, bool self,

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -296,11 +296,6 @@ namespace exotica
     req.distance = true;
     ps_->checkCollision(req, res, getCurrentState(), *acm_);
 
-    if (res.collision)
-      ROS_ERROR_STREAM("State in collision: " << res.distance);
-    else
-      ROS_INFO_STREAM("State NOT in collision: " << res.distance);
-
     return res.distance;
   }
 

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -58,7 +58,7 @@ namespace fcl_convert
 namespace exotica
 {
 ///////////////////////////////////////////////////////////////
-///////////////////////	Collision Scene	///////////////////////
+/////////////////////// Collision Scene ///////////////////////
 ///////////////////////////////////////////////////////////////
   CollisionScene::CollisionScene(const std::string & scene_name)
       : compute_dist(true), stateCheckCnt_(0), scene_name_(scene_name)
@@ -274,7 +274,8 @@ namespace exotica
     return dist == 0 ? !res.collision : res.distance > dist;
   }
 
-  bool CollisionScene::isStateValid(const Eigen::VectorXd &q, bool self)
+  // NB: need to check whether this function works as intended
+  bool CollisionScene::isStateValid(const Eigen::VectorXd &q)
   {
     update(q);
     return ps_->isStateValid(ps_->getCurrentState());

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -289,8 +289,6 @@ namespace exotica
     collision_detection::CollisionRequest req;
     collision_detection::CollisionResult res;
 
-    double selfCollisionDistance, distanceToEnvironment;
-
     // Check for both self- and world-collisions
     req.contacts = false;
     req.distance = true;

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -527,22 +527,25 @@ namespace exotica
 
       collision_scene_.reset(new CollisionScene(name_));
 
-      if (Server::isRos())
-      {
-          ps_pub_ = Server::advertise<moveit_msgs::PlanningScene>(name_ + "/PlanningScene", 100, true);
-          if(debug_) HIGHLIGHT_NAMED(name_, "Running in debug mode, planning scene will be published to '"<<Server::Instance()->getName()<<"/"<<name_<<"/PlanningScene'");
+      if (Server::isRos()) {
+        ps_pub_ = Server::advertise<moveit_msgs::PlanningScene>(
+            name_ + "/PlanningScene", 100, true);
+        if (debug_)
+          HIGHLIGHT_NAMED(
+              name_,
+              "Running in debug mode, planning scene will be published to '"
+                  << Server::Instance()->getName() << "/" << name_
+                  << "/PlanningScene'");
       }
-      else
-      {
-          visual_debug_ = false;
-      }
+
       {
           planning_scene::PlanningScenePtr tmp(new planning_scene::PlanningScene(model_));
           moveit_msgs::PlanningScenePtr msg(new moveit_msgs::PlanningScene());
           tmp->getPlanningSceneMsg(*msg.get());
           collision_scene_->initialise(msg, kinematica_.getJointNames(), "", BaseType,model_);
       }
-      if(debug_) INFO_NAMED(name_, "Exotica Scene initialised");
+      
+      if (debug_) INFO_NAMED(name_, "Exotica Scene initialized");
   }
 
   std::shared_ptr<KinematicResponse> Scene::RequestKinematics(KinematicsRequest& Request)
@@ -554,7 +557,7 @@ namespace exotica
   {
       collision_scene_->update(x);
       kinematica_.Update(x);
-      if (visual_debug_) publishScene();
+      if (debug_) publishScene();
   }
 
   void Scene::publishScene()

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -110,19 +110,23 @@ namespace exotica
   }
 
   void CollisionScene::updateWorld(
-      const moveit_msgs::PlanningSceneWorldConstPtr & world)
-  {
-//    for (int i=0;i<world->collision_objects.size();i++)
-//    {
-//      if(trans_world_.find(world->collision_objects[i].id) != trans_world_.end())
-//      {
-//        std::map<std::string, fcls_ptr>::iterator it = trans_world_.find(world->collision_objects[i].id);
-//        for(int j =0;j<it->second.size();j++)
-//        {
-//          it->second[j] = fcl::Transform3f(collision_detection::transform2fcl(world->collision_objects[i].mesh_poses[j]));
-//        }
-//      }
-//    }
+      const moveit_msgs::PlanningSceneWorldConstPtr& world) {
+    ps_->processPlanningSceneWorldMsg(*world);
+
+    //    for (int i=0;i<world->collision_objects.size();i++)
+    //    {
+    //      if(trans_world_.find(world->collision_objects[i].id) !=
+    //      trans_world_.end())
+    //      {
+    //        std::map<std::string, fcls_ptr>::iterator it =
+    //        trans_world_.find(world->collision_objects[i].id);
+    //        for(int j =0;j<it->second.size();j++)
+    //        {
+    //          it->second[j] =
+    //          fcl::Transform3f(collision_detection::transform2fcl(world->collision_objects[i].mesh_poses[j]));
+    //        }
+    //      }
+    //    }
   }
 
   void CollisionScene::update(Eigen::VectorXdRefConst x)

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -527,7 +527,7 @@ namespace exotica
 
       collision_scene_.reset(new CollisionScene(name_));
 
-      if (Server::isRos() && visual_debug_)
+      if (Server::isRos())
       {
           ps_pub_ = Server::advertise<moveit_msgs::PlanningScene>(name_ + "/PlanningScene", 100, true);
           if(debug_) HIGHLIGHT_NAMED(name_, "Running in debug mode, planning scene will be published to '"<<Server::Instance()->getName()<<"/"<<name_<<"/PlanningScene'");

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -112,17 +112,17 @@ namespace exotica
   void CollisionScene::updateWorld(
       const moveit_msgs::PlanningSceneWorldConstPtr & world)
   {
-//		for (int i=0;i<world->collision_objects.size();i++)
-//		{
-//			if(trans_world_.find(world->collision_objects[i].id) != trans_world_.end())
-//			{
-//				std::map<std::string, fcls_ptr>::iterator it = trans_world_.find(world->collision_objects[i].id);
-//				for(int j =0;j<it->second.size();j++)
-//				{
-//					it->second[j] = fcl::Transform3f(collision_detection::transform2fcl(world->collision_objects[i].mesh_poses[j]));
-//				}
-//			}
-//		}
+//    for (int i=0;i<world->collision_objects.size();i++)
+//    {
+//      if(trans_world_.find(world->collision_objects[i].id) != trans_world_.end())
+//      {
+//        std::map<std::string, fcls_ptr>::iterator it = trans_world_.find(world->collision_objects[i].id);
+//        for(int j =0;j<it->second.size();j++)
+//        {
+//          it->second[j] = fcl::Transform3f(collision_detection::transform2fcl(world->collision_objects[i].mesh_poses[j]));
+//        }
+//      }
+//    }
   }
 
   void CollisionScene::update(Eigen::VectorXdRefConst x)
@@ -341,7 +341,7 @@ namespace exotica
             {
               if (distance(fcl_link, it.second, req, res, safeDist) < 0)
               {
-//							INDICATE_FAILURE
+//              INDICATE_FAILURE
                 d = -1;
                 return; // WARNING;
               }
@@ -478,7 +478,7 @@ namespace exotica
   }
 
 ///////////////////////////////////////////////////////////////
-///////////////////////	EXOTica Scene	///////////////////////
+/////////////////////// EXOTica Scene ///////////////////////
 ///////////////////////////////////////////////////////////////
 
   Scene::Scene() : name_("Unnamed")
@@ -646,5 +646,5 @@ namespace exotica
   }
 
 }
-//	namespace exotica
+//  namespace exotica
 

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -281,6 +281,25 @@ namespace exotica
     return ps_->isStateValid(ps_->getCurrentState());
   }
 
+  double CollisionScene::getClosestDistance() {
+    collision_detection::CollisionRequest req;
+    collision_detection::CollisionResult res;
+
+    double selfCollisionDistance, distanceToEnvironment;
+
+    // Check for both self- and world-collisions
+    req.contacts = false;
+    req.distance = true;
+    ps_->checkCollision(req, res, getCurrentState(), *acm_);
+
+    if (res.collision)
+      ROS_ERROR_STREAM("State in collision: " << res.distance);
+    else
+      ROS_INFO_STREAM("State NOT in collision: " << res.distance);
+
+    return res.distance;
+  }
+
   void CollisionScene::getRobotDistance(const std::string & link, bool self,
       double & d, Eigen::Vector3d & p1, Eigen::Vector3d & p2,
       Eigen::Vector3d & norm, Eigen::Vector3d & c1, Eigen::Vector3d & c2,

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -492,6 +492,7 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("getModelStateMap", &Scene::getModelStateMap);
     scene.def("setModelState", (void (Scene::*)(Eigen::VectorXdRefConst)) &Scene::setModelState);
     scene.def("setModelStateMap", (void (Scene::*)(std::map<std::string, double>)) &Scene::setModelState);
+    scene.def("publishScene", &Scene::publishScene);
     // CollisionScene-related functions exposed via Scene - NB: may change in future    
     scene.def("getClosestDistance", [](Scene* instance) {
         return instance->getCollisionScene()->getClosestDistance();

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -554,6 +554,15 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("getClosestDistance", [](Scene* instance) {
         return instance->getCollisionScene()->getClosestDistance();
     });
+    scene.def("isStateValid", [](Scene* instance) {
+        return instance->getCollisionScene()->isStateValid();
+    });
+    scene.def("isStateValid", [](Scene* instance, bool self, double dist) {
+        return instance->getCollisionScene()->isStateValid(self, dist);
+    });
+    scene.def("isStateValid", [](Scene* instance, const Eigen::VectorXd &q) {
+        return instance->getCollisionScene()->isStateValid(q);
+    });
     scene.def("updateWorld", [](Scene* instance, moveit_msgs::PlanningSceneWorld& world) {
         moveit_msgs::PlanningSceneWorldConstPtr myPtr(new moveit_msgs::PlanningSceneWorld(world));
         instance->getCollisionScene()->updateWorld(myPtr);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -492,7 +492,7 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("getModelStateMap", &Scene::getModelStateMap);
     scene.def("setModelState", (void (Scene::*)(Eigen::VectorXdRefConst)) &Scene::setModelState);
     scene.def("setModelStateMap", (void (Scene::*)(std::map<std::string, double>)) &Scene::setModelState);
-
+    // CollisionScene-related functions exposed via Scene - NB: may change in future    
     scene.def("getClosestDistance", [](Scene* instance) {
         return instance->getCollisionScene()->getClosestDistance();
     });

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -74,11 +74,10 @@ PyObject* createStringIOObject() {
     PYBIND11_TYPE_CASTER(MessageType, _("genpy.Message"));                    \
                                                                               \
     bool load(handle src, bool) {                                             \
-      PyObject* source = src.ptr();                                           \
       PyObject* stringio = createStringIOObject();                            \
       if (!stringio) throw_pretty("Can't create StringIO instance.");         \
       PyObject* result =                                                      \
-          PyObject_CallMethod(source, "serialize", "O", stringio);            \
+          PyObject_CallMethod(src.ptr(), "serialize", "O", stringio);         \
       if (!result) throw_pretty("Can't serialize.");                          \
       result = PyObject_CallMethod(stringio, "getvalue", nullptr);            \
       if (!result) throw_pretty("Can't get buffer.");                         \
@@ -91,7 +90,6 @@ PyObject* createStringIOObject() {
       ros::serialization::deserialize<MessageType>(stream, value);            \
       delete[] udata;                                                         \
       delete[] data;                                                          \
-      Py_DECREF(source);                                                      \
       Py_DECREF(stringio);                                                    \
       Py_DECREF(result);                                                      \
       return !PyErr_Occurred();                                               \

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -554,6 +554,10 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("getClosestDistance", [](Scene* instance) {
         return instance->getCollisionScene()->getClosestDistance();
     });
+    scene.def("updateWorld", [](Scene* instance, moveit_msgs::PlanningSceneWorld& world) {
+        moveit_msgs::PlanningSceneWorldConstPtr myPtr(new moveit_msgs::PlanningSceneWorld(world));
+        instance->getCollisionScene()->updateWorld(myPtr);
+    });
 
     py::module kin = module.def_submodule("Kinematics","Kinematics submodule.");
     py::class_<KinematicTree, std::shared_ptr<KinematicTree>> kinematicTree(kin, "KinematicTree");

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -493,6 +493,10 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("setModelState", (void (Scene::*)(Eigen::VectorXdRefConst)) &Scene::setModelState);
     scene.def("setModelStateMap", (void (Scene::*)(std::map<std::string, double>)) &Scene::setModelState);
 
+    scene.def("getClosestDistance", [](Scene* instance) {
+        return instance->getCollisionScene()->getClosestDistance();
+    });
+
     py::module kin = module.def_submodule("Kinematics","Kinematics submodule.");
     py::class_<KinematicTree, std::shared_ptr<KinematicTree>> kinematicTree(kin, "KinematicTree");
     kinematicTree.def("publishFrames", &KinematicTree::publishFrames);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -60,10 +60,9 @@ PyObject* createStringIOObject() {
   if (!cls) throw_pretty("Can't load StringIO class.");
   PyObject* stringio = PyObject_CallObject(cls, NULL);
   if (!stringio) throw_pretty("Can't create StringIO object.");
-
+  Py_DECREF(module);
+  Py_DECREF(cls);
   return stringio;
-
-  // Do we need to run Py_DECREF ?
 }
 
 #define ROS_MESSAGE_WRAPPER(MessageType)                                      \
@@ -91,6 +90,10 @@ PyObject* createStringIOObject() {
       ros::serialization::IStream stream(udata, len);                         \
       ros::serialization::deserialize<MessageType>(stream, value);            \
       delete[] udata;                                                         \
+      delete[] data;                                                          \
+      Py_DECREF(source);                                                      \
+      Py_DECREF(stringio);                                                    \
+      Py_DECREF(result);                                                      \
       return !PyErr_Occurred();                                               \
     }                                                                         \
                                                                               \


### PR DESCRIPTION
- Adds ``getClosestDistance`` to ``CollisionScene`` with MoveIt collision checking and wraps it for Python (through ``Scene``)
- Removes ``self`` argument from ``isStateValid(q)`` overload as unused (a step towards simplifying #39) - it was unused in all online exotica-based projects
- Unified ``debug_`` and ``visual_debug_`` as the latter couldn't be enabled, ``debug_`` can be set interactively from Python (``debugMode=True``)
- Exposes ``publishScene``
- Adds wrapping for ROS message types (should work for both Python 2 and 3, only tested with Python2 for now) (Resolves #100)
- Add option to update the planning scene from Python via ``moveit_msgs::PlanningSceneWorld``
- Exposes the different overloads for ``isStateValid`` and resolves #39 as cannot be reproduced