### PR TITLE
exotica_python: Add PlanningSceneUtils

### DIFF
--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -256,6 +256,7 @@ namespace exotica
       std::map<std::string, double> getModelStateMap();
       void setModelState(Eigen::VectorXdRefConst x);
       void setModelState(std::map<std::string, double> x);
+      std::string getGroupName();
 
       BASE_TYPE getBaseType()
       {
@@ -263,6 +264,10 @@ namespace exotica
       }
 
       void publishScene();
+      void loadScene(const std::string& scene);
+      void loadSceneFile(const std::string& file_name);
+      std::string getScene();
+      void cleanScene();
     private:
       ///	The name of the scene
       std::string name_;

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -131,7 +131,7 @@ namespace exotica
        * \brief Check for the closest distance in the planning scene including both self- and world-collisions
        * @return The closest distance - negative values indicate penetration.
        */
-      double getClosestDistance(bool debug = false);
+      double getClosestDistance(bool computeSelfCollisionDistance = true, bool debug = false);
 
       /**
        * \brief	Get closest distance between robot link and any other objects

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -131,7 +131,7 @@ namespace exotica
        * \brief Check for the closest distance in the planning scene including both self- and world-collisions
        * @return The closest distance - negative values indicate penetration.
        */
-      double getClosestDistance();
+      double getClosestDistance(bool debug = false);
 
       /**
        * \brief	Get closest distance between robot link and any other objects

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -31,6 +31,8 @@
  */
 
 #include "exotica/Scene.h"
+#include <iostream>
+#include <fstream>
 
 namespace fcl_convert
 {
@@ -677,6 +679,35 @@ namespace exotica
   Eigen::VectorXd Scene::getControlledState()
   {
       return kinematica_.getControlledState();
+  }
+
+  std::string Scene::getGroupName()
+  {
+      return group->getName();
+  }
+
+  void Scene::loadScene(const std::string& scene)
+  {
+      std::stringstream ss(scene);
+      getPlanningScene()->loadGeometryFromStream(ss);
+  }
+
+  void Scene::loadSceneFile(const std::string& file_name)
+  {
+      std::ifstream ss(parsePath(file_name));
+      getPlanningScene()->loadGeometryFromStream(ss);
+  }
+
+  std::string Scene::getScene()
+  {
+      std::stringstream ss;
+      getPlanningScene()->saveGeometryToStream(ss);
+      return ss.str();
+  }
+
+  void Scene::cleanScene()
+  {
+      getPlanningScene()->removeAllCollisionObjects();
   }
 
 }

--- a/exotica_python/CMakeLists.txt
+++ b/exotica_python/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(exotica_python)
 
+# Python2 uses char* and Python3 const char* for arguments so explicit casting
+# of string literals would require define flags. Alternatively, deactivate
+# warnings for now
+add_definitions(-Wno-write-strings)
+
 find_package(catkin REQUIRED COMPONENTS
   exotica
   pybind11_catkin

--- a/exotica_python/package.xml
+++ b/exotica_python/package.xml
@@ -8,4 +8,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <depend>exotica</depend>
   <depend>pybind11_catkin</depend>
+  <depend>moveit_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>shape_msgs</depend>
 </package>

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -561,6 +561,9 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("getClosestDistance", [](Scene* instance) {
         return instance->getCollisionScene()->getClosestDistance();
     });
+    scene.def("getClosestDistance", [](Scene* instance,bool debug) {
+        return instance->getCollisionScene()->getClosestDistance(debug);
+    });
     scene.def("isStateValid", [](Scene* instance) {
         return instance->getCollisionScene()->isStateValid();
     });

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -561,8 +561,8 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("getClosestDistance", [](Scene* instance) {
         return instance->getCollisionScene()->getClosestDistance();
     });
-    scene.def("getClosestDistance", [](Scene* instance,bool debug) {
-        return instance->getCollisionScene()->getClosestDistance(debug);
+    scene.def("getClosestDistance", [](Scene* instance, bool selfCheck, bool debug) {
+        return instance->getCollisionScene()->getClosestDistance(selfCheck, debug);
     });
     scene.def("isStateValid", [](Scene* instance) {
         return instance->getCollisionScene()->isStateValid();

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -577,6 +577,10 @@ PYBIND11_MODULE(_pyexotica, module)
         moveit_msgs::PlanningSceneWorldConstPtr myPtr(new moveit_msgs::PlanningSceneWorld(world));
         instance->getCollisionScene()->updateWorld(myPtr);
     });
+    scene.def("loadScene", &Scene::loadScene);
+    scene.def("loadSceneFile", &Scene::loadSceneFile);
+    scene.def("getScene", &Scene::getScene);
+    scene.def("cleanScene", &Scene::cleanScene);
 
     py::module kin = module.def_submodule("Kinematics","Kinematics submodule.");
     py::class_<KinematicTree, std::shared_ptr<KinematicTree>> kinematicTree(kin, "KinematicTree");

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -104,7 +104,9 @@ PyObject* createStringIOObject() {
   };                                                                          \
   }                                                                           \
   }
+#include <moveit_msgs/PlanningScene.h>
 #include <moveit_msgs/PlanningSceneWorld.h>
+ROS_MESSAGE_WRAPPER(moveit_msgs::PlanningScene);
 ROS_MESSAGE_WRAPPER(moveit_msgs::PlanningSceneWorld);
 
 std::string version()
@@ -551,6 +553,10 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("setModelState", (void (Scene::*)(Eigen::VectorXdRefConst)) &Scene::setModelState);
     scene.def("setModelStateMap", (void (Scene::*)(std::map<std::string, double>)) &Scene::setModelState);
     scene.def("publishScene", &Scene::publishScene);
+    scene.def("setCollisionScene", [](Scene* instance, moveit_msgs::PlanningScene& ps) {
+        moveit_msgs::PlanningSceneConstPtr myPtr(new moveit_msgs::PlanningScene(ps));
+        instance->setCollisionScene(myPtr);
+    });
     // CollisionScene-related functions exposed via Scene - NB: may change in future    
     scene.def("getClosestDistance", [](Scene* instance) {
         return instance->getCollisionScene()->getClosestDistance();

--- a/exotica_python/src/pyexotica/PlanningSceneUtils.py
+++ b/exotica_python/src/pyexotica/PlanningSceneUtils.py
@@ -1,6 +1,7 @@
 from moveit_msgs.msg import CollisionObject
 from geometry_msgs.msg import Pose, Point
 from shape_msgs.msg import SolidPrimitive, Plane, Mesh, MeshTriangle
+import pyexotica as exo
 
 try:
     from pyassimp import pyassimp
@@ -52,7 +53,7 @@ def create_box(name, pose, size, frame_id='/world_frame'):
 def create_mesh(name, pose, filename, scale=(1, 1, 1),
                 frame_id='/world_frame'):
     co = CollisionObject()
-    scene = pyassimp.load(filename)
+    scene = pyassimp.load(exo.Tools.parsePath(filename))
     if not scene.meshes or len(scene.meshes) == 0:
         raise Exception("There are no meshes in the file")
     if len(scene.meshes[0].faces) == 0:

--- a/exotica_python/src/pyexotica/PlanningSceneUtils.py
+++ b/exotica_python/src/pyexotica/PlanningSceneUtils.py
@@ -1,0 +1,106 @@
+from moveit_msgs.msg import CollisionObject
+from geometry_msgs.msg import Pose, Point
+from shape_msgs.msg import SolidPrimitive, Plane, Mesh, MeshTriangle
+
+try:
+    from pyassimp import pyassimp
+except:
+    try:
+        import pyassimp
+    except:
+        raise Exception("Failed to import pyassimp")
+
+
+def create_pose(position, orientation, frame='/world_frame'):
+    pose = Pose()
+    pose.position.x = position[0]
+    pose.position.y = position[1]
+    pose.position.z = position[2]
+    pose.orientation.x = orientation[0]
+    pose.orientation.y = orientation[1]
+    pose.orientation.z = orientation[2]
+    pose.orientation.w = orientation[3]
+    return pose
+
+
+def create_sphere(name, pose, radius, frame_id='/world_frame'):
+    co = CollisionObject()
+    co.operation = CollisionObject.ADD
+    co.id = name
+    co.header.frame_id = frame_id
+    sphere = SolidPrimitive()
+    sphere.type = SolidPrimitive.SPHERE
+    sphere.dimensions = [radius]
+    co.primitives = [sphere]
+    co.primitive_poses = [pose]
+    return co
+
+
+def create_box(name, pose, size, frame_id='/world_frame'):
+    co = CollisionObject()
+    co.operation = CollisionObject.ADD
+    co.id = name
+    co.header.frame_id = frame_id
+    box = SolidPrimitive()
+    box.type = SolidPrimitive.BOX
+    box.dimensions = list(size)
+    co.primitives = [box]
+    co.primitive_poses = [pose]
+    return co
+
+
+def create_mesh(name, pose, filename, scale=(1, 1, 1),
+                frame_id='/world_frame'):
+    co = CollisionObject()
+    scene = pyassimp.load(filename)
+    if not scene.meshes or len(scene.meshes) == 0:
+        raise Exception("There are no meshes in the file")
+    if len(scene.meshes[0].faces) == 0:
+        raise Exception("There are no faces in the mesh")
+    co.operation = CollisionObject.ADD
+    co.id = name
+    co.header.frame_id = frame_id
+
+    mesh = Mesh()
+    first_face = scene.meshes[0].faces[0]
+    if hasattr(first_face, '__len__'):
+        for face in scene.meshes[0].faces:
+            if len(face) == 3:
+                triangle = MeshTriangle()
+                triangle.vertex_indices = [face[0], face[1], face[2]]
+                mesh.triangles.append(triangle)
+    elif hasattr(first_face, 'indices'):
+        for face in scene.meshes[0].faces:
+            if len(face.indices) == 3:
+                triangle = MeshTriangle()
+                triangle.vertex_indices = [face.indices[0],
+                                           face.indices[1],
+                                           face.indices[2]]
+                mesh.triangles.append(triangle)
+    else:
+        raise Exception(
+            "Unable to build triangles from mesh")
+    for vertex in scene.meshes[0].vertices:
+        point = Point()
+        point.x = vertex[0]*scale[0]
+        point.y = vertex[1]*scale[1]
+        point.z = vertex[2]*scale[2]
+        mesh.vertices.append(point)
+    co.meshes = [mesh]
+    co.mesh_poses = [pose]
+    pyassimp.release(scene)
+    return co
+
+
+def create_plane(name, pose, normal=(0, 0, 1), offset=0,
+                 frame_id='/world_frame'):
+    co = CollisionObject()
+    co.operation = CollisionObject.ADD
+    co.id = name
+    co.header.frame_id = frame_id
+    p = Plane()
+    p.coef = list(normal)
+    p.coef.append(offset)
+    co.planes = [p]
+    co.plane_poses = [pose]
+    return co


### PR DESCRIPTION
- Adds convenience functions to easily create collision objects that can be added to a ``moveit_msgs::PlanningSceneWorld``
- Supports building mesh objects from files (currently requires absolute paths for mesh files)

Setup with a few lines of Python:
![image](https://user-images.githubusercontent.com/1664508/30117075-1909671a-9317-11e7-9519-eca12d437118.png)
