### PR TITLE
Fix planning scene update from kinematics update

### DIFF
--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -92,6 +92,14 @@ namespace exotica
       void update(Eigen::VectorXdRefConst x);
 
       /**
+       * @brief      Update an individual joint's value in the planning scene
+       *
+       * @param[in]  joint  The joint
+       * @param[in]  value  The value
+       */
+      void update(std::string joint, double value);
+
+      /**
        * \brief	Get closest distance between two objects
        * @param	o1		Name of object 1
        * @param	o2		Name of object 2

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -498,7 +498,6 @@ void KinematicTree::setModelState(Eigen::VectorXdRefConst x)
 
 void KinematicTree::setModelState(std::map<std::string, double> x)
 {
-    if(x.size()!=ModelJointsNames.size()) throw_pretty("Model state vector has wrong size, expected " << ModelJointsNames.size() << " got " << x.size());
     for(auto& joint : x)
     {
         try

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -494,6 +494,10 @@ void KinematicTree::setModelState(Eigen::VectorXdRefConst x)
     {
         TreeState(ModelJointsMap.at(ModelJointsNames[i])->Id) = x(i);
     }
+
+    UpdateFK();
+    if (Flags & KIN_J) UpdateJ();
+    if (Debug) publishFrames();
 }
 
 void KinematicTree::setModelState(std::map<std::string, double> x)
@@ -509,6 +513,10 @@ void KinematicTree::setModelState(std::map<std::string, double> x)
             throw_pretty("Robot model does not contain joint '"<<joint.first<<"'");
         }
     }
+
+    UpdateFK();
+    if (Flags & KIN_J) UpdateJ();
+    if (Debug) publishFrames();
 }
 
 Eigen::VectorXd KinematicTree::getControlledState()

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -131,6 +131,16 @@ namespace exotica
     //    }
   }
 
+  void CollisionScene::update(std::string joint, double value) {
+    try {
+      ps_->getCurrentStateNonConst().setVariablePosition(joint, value);
+    } catch (const std::exception& ex) {
+      throw_pretty("Exception while trying to update individual joint '"
+                   << joint << "': " << ex.what());
+    }
+    ps_->getCurrentStateNonConst().update(true);
+  }
+
   void CollisionScene::update(Eigen::VectorXdRefConst x)
   {
     if (joint_index_.size() != x.rows())

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -676,14 +676,30 @@ namespace exotica
     return kinematica_.getModelStateMap();
   }
 
-  void Scene::setModelState(Eigen::VectorXdRefConst x)
-  {
+  void Scene::setModelState(Eigen::VectorXdRefConst x) {
+    // Update Kinematica internal state
     kinematica_.setModelState(x);
+
+    // Update Planning Scene State
+    int i = 0;
+    for (auto& joint : getModelJointNames()) {
+      collision_scene_->update(joint, x(i));
+      i++;
+    }
+
+    if (debug_) publishScene();
   }
 
-  void Scene::setModelState(std::map<std::string, double> x)
-  {
+  void Scene::setModelState(std::map<std::string, double> x) {
+    // Update Kinematica internal state
     kinematica_.setModelState(x);
+
+    // Update Planning Scene State
+    for (auto& joint : x) {
+      collision_scene_->update(joint.first, joint.second);
+    }
+
+    if (debug_) publishScene();
   }
 
   Eigen::VectorXd Scene::getControlledState()

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -131,7 +131,8 @@ namespace exotica
     //    }
   }
 
-  void CollisionScene::update(std::string joint, double value) {
+  void CollisionScene::update(std::string joint, double value)
+  {
     try {
       ps_->getCurrentStateNonConst().setVariablePosition(joint, value);
     } catch (const std::exception& ex) {
@@ -676,13 +677,15 @@ namespace exotica
     return kinematica_.getModelStateMap();
   }
 
-  void Scene::setModelState(Eigen::VectorXdRefConst x) {
+  void Scene::setModelState(Eigen::VectorXdRefConst x)
+  {
     // Update Kinematica internal state
     kinematica_.setModelState(x);
 
     // Update Planning Scene State
     int i = 0;
-    for (auto& joint : getModelJointNames()) {
+    for (auto& joint : getModelJointNames())
+    {
       collision_scene_->update(joint, x(i));
       i++;
     }
@@ -695,9 +698,8 @@ namespace exotica
     kinematica_.setModelState(x);
 
     // Update Planning Scene State
-    for (auto& joint : x) {
+    for (auto& joint : x)
       collision_scene_->update(joint.first, joint.second);
-    }
 
     if (debug_) publishScene();
   }

--- a/exotica_python/src/pyexotica/PlanningSceneUtils.py
+++ b/exotica_python/src/pyexotica/PlanningSceneUtils.py
@@ -53,7 +53,7 @@ def create_box(name, pose, size, frame_id='/world_frame'):
 def create_mesh(name, pose, filename, scale=(1, 1, 1),
                 frame_id='/world_frame'):
     co = CollisionObject()
-    scene = pyassimp.load(exo.Tools.parsePath(filename))
+    scene = pyassimp.load(str(exo.Tools.parsePath(filename)))
     if not scene.meshes or len(scene.meshes) == 0:
         raise Exception("There are no meshes in the file")
     if len(scene.meshes[0].faces) == 0:


### PR DESCRIPTION
Includes:

- ``setModelState`` can now be called with subsets of the full state vector when passing in a map - the check was not required and often we get updates from different nodes so won't have the full vector available
- ``setModelState`` has been fixed to trigger recomputation of FK and Jacobian as well as publish debug frames
- Added ``update(joint_name, value)`` method to ``CollisionScene`` to update single joints by name
- Fixed ``Scene::setModelState`` to also update the collision scene, resolves #103 