### PR TITLE
Allow Scenes to have arbitrary base type/ independent of KinematicTree's base type

### DIFF
--- a/exotica/include/exotica/Problems/UnconstrainedEndPoseProblem.h
+++ b/exotica/include/exotica/Problems/UnconstrainedEndPoseProblem.h
@@ -54,6 +54,8 @@ namespace exotica
         void setRho(const std::string & task_name, const double rho);
         Eigen::VectorXd getGoal(const std::string & task_name);
         double getRho(const std::string & task_name);
+        Eigen::VectorXd getNominalPose();
+        void setNominalPose(Eigen::VectorXdRefConst qNominal_in);
 
         Eigen::VectorXd Rho;
         TaskSpaceVector y;

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -231,8 +231,8 @@ namespace exotica
       collision_detection::AllowedCollisionMatrixPtr acm_;
 
       std::string scene_name_;
+      std::string world_joint_ = "";
       BASE_TYPE BaseType;
-
   };
 
   typedef std::shared_ptr<CollisionScene> CollisionScene_ptr;

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -122,18 +122,11 @@ namespace exotica
           double safeDist);
 
       /**
-       * \brief	Check if the whole robot is valid (collision and feasibility)
+       * \brief	Check if the whole robot is valid (collision only)
        * @param	self	Indicate if self collision check is required
        * @return True, if the state is collision free.
        */
       bool isStateValid(bool self = true, double dist = 0);
-
-      /**
-       * \brief	Check if the whole robot is valid given a configuration
-       * @param	q		The configuration to check
-       * @return True, if the state is collision free.
-       */
-      bool isStateValid(const Eigen::VectorXd &q);
 
       /**
        * \brief Check for the closest distance in the planning scene including both self- and world-collisions

--- a/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
@@ -149,5 +149,19 @@ namespace exotica
             throw_pretty("Cannot get Rho. Task map '"<<task_name<<"' does not exist.");
         }
     }
+
+    Eigen::VectorXd UnconstrainedEndPoseProblem::getNominalPose()
+    {
+        return qNominal;
+    }
+
+    void UnconstrainedEndPoseProblem::setNominalPose(Eigen::VectorXdRefConst qNominal_in)
+    {
+      if (qNominal_in.rows() == N)
+        qNominal = qNominal_in;
+      else
+        throw_pretty("Cannot set qNominal - wrong number of rows (expected "
+                     << N << ", received " << qNominal_in.rows() << ").");
+    }
 }
 

--- a/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
@@ -81,8 +81,8 @@ namespace exotica
 
         qNominal = init.NominalState;
 
-        if(init.Rho.rows()>0 && init.Rho.rows()!=NumTasks) throw_named("Invalide size of Rho (" << init.Rho.rows() << ") expected: "<< NumTasks);
-        if(init.Goal.rows()>0 && init.Goal.rows()!=PhiN) throw_named("Invalide size of Rho (" << init.Goal.rows() << ") expected: "<< PhiN);
+        if(init.Rho.rows()>0 && init.Rho.rows()!=NumTasks) throw_named("Invalid size of Rho (" << init.Rho.rows() << ") expected: "<< NumTasks);
+        if(init.Goal.rows()>0 && init.Goal.rows()!=PhiN) throw_named("Invalid size of Rho (" << init.Goal.rows() << ") expected: "<< PhiN);
 
         if(init.Rho.rows()==NumTasks) Rho = init.Rho;
         if(init.Goal.rows()==PhiN) y.data = init.Goal;
@@ -107,7 +107,7 @@ namespace exotica
         }
         catch(std::out_of_range& e)
         {
-            throw_pretty("Cannot set Goal. Task map '"<<task_name<<"' Does not exist.");
+            throw_pretty("Cannot set Goal. Task map '"<<task_name<<"' does not exist.");
         }
     }
 
@@ -120,7 +120,7 @@ namespace exotica
         }
         catch(std::out_of_range& e)
         {
-            throw_pretty("Cannot set Rho. Task map '"<<task_name<<"' Does not exist.");
+            throw_pretty("Cannot set Rho. Task map '"<<task_name<<"' does not exist.");
         }
     }
 
@@ -133,7 +133,7 @@ namespace exotica
         }
         catch(std::out_of_range& e)
         {
-            throw_pretty("Cannot get Goal. Task map '"<<task_name<<"' Does not exist.");
+            throw_pretty("Cannot get Goal. Task map '"<<task_name<<"' does not exist.");
         }
     }
 
@@ -146,7 +146,7 @@ namespace exotica
         }
         catch(std::out_of_range& e)
         {
-            throw_pretty("Cannot get Rho. Task map '"<<task_name<<"' Does not exist.");
+            throw_pretty("Cannot get Rho. Task map '"<<task_name<<"' does not exist.");
         }
     }
 }

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -291,12 +291,6 @@ namespace exotica
     return dist == 0 ? !res.collision : res.distance > dist;
   }
 
-  bool CollisionScene::isStateValid(const Eigen::VectorXd &q)
-  {
-    update(q);
-    return ps_->isStateValid(ps_->getCurrentState());
-  }
-
   double CollisionScene::getClosestDistance(bool computeSelfCollisionDistance,
                                             bool debug) {
     collision_detection::CollisionRequest req;

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -468,6 +468,12 @@ PYBIND11_MODULE(_pyexotica, module)
         .value("Matrix", RotationType::MATRIX)
         .export_values();
 
+    py::enum_<BASE_TYPE>(module, "BaseType")
+        .value("Fixed", BASE_TYPE::FIXED)
+        .value("Floating", BASE_TYPE::FLOATING)
+        .value("Planar", BASE_TYPE::PLANAR)
+        .export_values();
+
     py::class_<TaskMap, std::shared_ptr<TaskMap>, Object> taskMap(module, "TaskMap");
     taskMap.def_readonly("id", &TaskMap::Id);
     taskMap.def_readonly("start", &TaskMap::Start);
@@ -545,6 +551,7 @@ PYBIND11_MODULE(_pyexotica, module)
 
     py::class_<Scene, std::shared_ptr<Scene>, Object> scene(module, "Scene");
     scene.def("Update", &Scene::Update);
+    scene.def("getBaseType", &Scene::getBaseType);
     scene.def("getJointNames", (std::vector<std::string> (Scene::*)()) &Scene::getJointNames);
     scene.def("getSolver", &Scene::getSolver, py::return_value_policy::reference_internal);
     scene.def("getModelJointNames", &Scene::getModelJointNames);
@@ -588,6 +595,7 @@ PYBIND11_MODULE(_pyexotica, module)
     kinematicTree.def("getJointLimits", &KinematicTree::getJointLimits);
     kinematicTree.def("getRootName", &KinematicTree::getRootName);
     kinematicTree.def("getUsedJointLimits", &KinematicTree::getUsedJointLimits);
+    kinematicTree.def("getBaseType", &KinematicTree::getBaseType);
 
     py::class_<KDL::Frame> kdlFrame (module, "KDLFrame");
     kdlFrame.def(py::init());

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -542,7 +542,7 @@ PYBIND11_MODULE(_pyexotica, module)
     unconstrainedEndPoseProblem.def_readonly("y", &UnconstrainedEndPoseProblem::y);
     unconstrainedEndPoseProblem.def_readonly("Phi", &UnconstrainedEndPoseProblem::Phi);
     unconstrainedEndPoseProblem.def_readonly("J", &UnconstrainedEndPoseProblem::J);
-    unconstrainedEndPoseProblem.def_readonly("qNominal", &UnconstrainedEndPoseProblem::qNominal);
+    unconstrainedEndPoseProblem.def_property("qNominal", &UnconstrainedEndPoseProblem::getNominalPose, &UnconstrainedEndPoseProblem::setNominalPose);
     py::class_<SamplingProblem, std::shared_ptr<SamplingProblem>, PlanningProblem> samplingProblem(prob, "SamplingProblem");
     samplingProblem.def("update", &SamplingProblem::Update);
     samplingProblem.def("setGoalState", &SamplingProblem::setGoalState);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -552,6 +552,7 @@ PYBIND11_MODULE(_pyexotica, module)
     py::class_<Scene, std::shared_ptr<Scene>, Object> scene(module, "Scene");
     scene.def("Update", &Scene::Update);
     scene.def("getBaseType", &Scene::getBaseType);
+    scene.def("getGroupName", &Scene::getGroupName);
     scene.def("getJointNames", (std::vector<std::string> (Scene::*)()) &Scene::getJointNames);
     scene.def("getSolver", &Scene::getSolver, py::return_value_policy::reference_internal);
     scene.def("getModelJointNames", &Scene::getModelJointNames);

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -578,9 +578,6 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("isStateValid", [](Scene* instance, bool self, double dist) {
         return instance->getCollisionScene()->isStateValid(self, dist);
     });
-    scene.def("isStateValid", [](Scene* instance, const Eigen::VectorXd &q) {
-        return instance->getCollisionScene()->isStateValid(q);
-    });
     scene.def("updateWorld", [](Scene* instance, moveit_msgs::PlanningSceneWorld& world) {
         moveit_msgs::PlanningSceneWorldConstPtr myPtr(new moveit_msgs::PlanningSceneWorld(world));
         instance->getCollisionScene()->updateWorld(myPtr);


### PR DESCRIPTION
This fixes #105 and also exposes ``getBaseType`` for both ``KinematicTree`` and ``Scene`` as well as ``getGroupName`` for ``Scene``.