### PR TITLE
KinematicTree BaseType clean-up and floating base joint limits fix

### DIFF
--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -178,7 +178,7 @@ namespace exotica
             ~KinematicTree() {}
             void Instantiate(std::string JointGroup, robot_model::RobotModelPtr model);
             std::string getRootName();
-            BASE_TYPE getBaseType();
+            BASE_TYPE getModelBaseType();
             std::shared_ptr<KinematicResponse> RequestFrames(const KinematicsRequest& request);
             void Update(Eigen::VectorXdRefConst x);
             void setJointLimits();

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -179,6 +179,7 @@ namespace exotica
             void Instantiate(std::string JointGroup, robot_model::RobotModelPtr model);
             std::string getRootName();
             BASE_TYPE getModelBaseType();
+            BASE_TYPE getControlledBaseType();
             std::shared_ptr<KinematicResponse> RequestFrames(const KinematicsRequest& request);
             void Update(Eigen::VectorXdRefConst x);
             void setJointLimits();
@@ -218,6 +219,7 @@ namespace exotica
             void ComputeJ(const KinematicFrame& frame, KDL::Jacobian& J);
 
             BASE_TYPE ModelBaseType;
+            BASE_TYPE ControlledBaseType;
             int NumControlledJoints; //!< Number of controlled joints in the joint group.
             int NumJoints; //!< Number of joints of the robot (including floating/plannar base, passive joints and uncontrolled joints).
             int StateSize;

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -217,7 +217,7 @@ namespace exotica
             void UpdateJ();
             void ComputeJ(const KinematicFrame& frame, KDL::Jacobian& J);
 
-            BASE_TYPE BaseType;
+            BASE_TYPE ModelBaseType;
             int NumControlledJoints; //!< Number of controlled joints in the joint group.
             int NumJoints; //!< Number of joints of the robot (including floating/plannar base, passive joints and uncontrolled joints).
             int StateSize;

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -219,7 +219,7 @@ namespace exotica
             void ComputeJ(const KinematicFrame& frame, KDL::Jacobian& J);
 
             BASE_TYPE ModelBaseType;
-            BASE_TYPE ControlledBaseType;
+            BASE_TYPE ControlledBaseType = BASE_TYPE::FIXED;
             int NumControlledJoints; //!< Number of controlled joints in the joint group.
             int NumJoints; //!< Number of joints of the robot (including floating/plannar base, passive joints and uncontrolled joints).
             int StateSize;

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -435,7 +435,7 @@ std::map<std::string, std::vector<double>> KinematicTree::getUsedJointLimits()
 void KinematicTree::setFloatingBaseLimitsPosXYZEulerZYX(
     const std::vector<double> & lower, const std::vector<double> & upper)
 {
-  if (BaseType != BASE_TYPE::FLOATING)
+  if (ControlledBaseType != BASE_TYPE::FLOATING)
   {
     throw_pretty("This is not a floating joint!");
   }
@@ -463,7 +463,7 @@ void KinematicTree::setJointLimits()
 
 ///	Manually defined floating base limits
 ///	Should be done more systematically with robot model class
-  if (BaseType == BASE_TYPE::FLOATING)
+  if (ControlledBaseType == BASE_TYPE::FLOATING)
   {
     ControlledJoints[0]->JointLimits = {-0.05, 0.05};
 
@@ -477,7 +477,7 @@ void KinematicTree::setJointLimits()
 
     ControlledJoints[5]->JointLimits = {-M_PI / 8, M_PI / 8};
   }
-  else if (BaseType == BASE_TYPE::PLANAR)
+  else if (ControlledBaseType == BASE_TYPE::PLANAR)
   {
     ControlledJoints[0]->JointLimits = {-10, 10};
 

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -385,7 +385,7 @@ Eigen::MatrixXd KinematicTree::getJointLimits()
     return lim;
 }
 
-exotica::BASE_TYPE KinematicTree::getBaseType()
+exotica::BASE_TYPE KinematicTree::getModelBaseType()
 {
   return ModelBaseType;
 }

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -199,6 +199,33 @@ void KinematicTree::BuildTree(const KDL::Tree & RobotKinematics)
         if(Joint->IsControlled) ControlledJointsMap[Joint->Segment.getJoint().getName()] = Joint;
     }
 
+    // The ModelBaseType defined above refers to the base type of the overall
+    // robot model - not of the set of controlled joints. E.g. a floating-
+    // base robot can have a scene defined where the floating-base virtual
+    // joint is _not_ part of the planning group/scene. Thus we need to
+    // establish the BaseTye of the joint group, the ControlledBaseType:
+    //
+    // Generally assume fixed base, then assess semantic information
+    ControlledBaseType = BASE_TYPE::FIXED;
+    // If there is a virtual joint, we need to check in detail whether it is a
+    // planar or floating base
+    if (Model->getSRDF()->getVirtualJoints().size() > 0) {
+      std::string world_joint = Model->getSRDF()->getVirtualJoints()[0].name_;
+
+      // A floating base in KinematicTree always contains trans_x, trans_y,
+      // trans_z, rot_x, rot_y, rot_z (XYZRPY, 6-DoF)
+      if (std::find(ControlledJointsNames.begin(),
+                    ControlledJointsNames.end(),
+                    world_joint + "/trans_x") != ControlledJointsNames.end())
+        ControlledBaseType = BASE_TYPE::FLOATING;
+      // A planar base in Kinematica always contains x, y, theta (3-DoF)
+      else if (std::find(ControlledJointsNames.begin(),
+                         ControlledJointsNames.end(),
+                         world_joint + "/theta") !=
+               ControlledJointsNames.end())
+        ControlledBaseType = BASE_TYPE::PLANAR;
+    }
+
     setJointLimits();
 }
 
@@ -388,6 +415,11 @@ Eigen::MatrixXd KinematicTree::getJointLimits()
 exotica::BASE_TYPE KinematicTree::getModelBaseType()
 {
   return ModelBaseType;
+}
+
+exotica::BASE_TYPE KinematicTree::getControlledBaseType()
+{
+  return ControlledBaseType;
 }
 
 std::map<std::string, std::vector<double>> KinematicTree::getUsedJointLimits()

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -147,12 +147,12 @@ void KinematicTree::BuildTree(const KDL::Tree & RobotKinematics)
     if(WorldFrameName == "") throw_pretty("Can't initialize root joint!");
     if(RootJoint->getType()==robot_model::JointModel::FIXED)
     {
-        BaseType = BASE_TYPE::FIXED;
+        ModelBaseType = BASE_TYPE::FIXED;
         Tree.push_back(std::shared_ptr<KinematicElement>(new KinematicElement(Tree.size(), nullptr, KDL::Segment(WorldFrameName, KDL::Joint(RootJoint->getName(), KDL::Joint::None))  )));
     }
     else if(RootJoint->getType() == robot_model::JointModel::FLOATING)
     {
-        BaseType = BASE_TYPE::FLOATING;
+        ModelBaseType = BASE_TYPE::FLOATING;
         Tree.resize(6);
         KDL::Joint::JointType types[] = {KDL::Joint::TransX, KDL::Joint::TransY, KDL::Joint::TransZ, KDL::Joint::RotX, KDL::Joint::RotY, KDL::Joint::RotZ};
         for(int i=0;i<6;i++)
@@ -167,7 +167,7 @@ void KinematicTree::BuildTree(const KDL::Tree & RobotKinematics)
     }
     else if(RootJoint->getType() ==  robot_model::JointModel::PLANAR)
     {
-        BaseType = BASE_TYPE::PLANAR;
+        ModelBaseType = BASE_TYPE::PLANAR;
         Tree.resize(3);
         KDL::Joint::JointType types[] = {KDL::Joint::TransX, KDL::Joint::TransY, KDL::Joint::RotZ};
         for(int i=0;i<3;i++)
@@ -387,7 +387,7 @@ Eigen::MatrixXd KinematicTree::getJointLimits()
 
 exotica::BASE_TYPE KinematicTree::getBaseType()
 {
-  return BaseType;
+  return ModelBaseType;
 }
 
 std::map<std::string, std::vector<double>> KinematicTree::getUsedJointLimits()

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -196,34 +196,21 @@ void KinematicTree::BuildTree(const KDL::Tree & RobotKinematics)
         if(Joint->IsControlled) ControlledJoints[Joint->ControlId] = Joint;
         TreeMap[Joint->Segment.getName()] = Joint;
         ModelJointsMap[Joint->Segment.getJoint().getName()] = Joint;
-        if(Joint->IsControlled) ControlledJointsMap[Joint->Segment.getJoint().getName()] = Joint;
-    }
+        if (Joint->IsControlled) {
+          ControlledJointsMap[Joint->Segment.getJoint().getName()] = Joint;
 
-    // The ModelBaseType defined above refers to the base type of the overall
-    // robot model - not of the set of controlled joints. E.g. a floating-
-    // base robot can have a scene defined where the floating-base virtual
-    // joint is _not_ part of the planning group/scene. Thus we need to
-    // establish the BaseTye of the joint group, the ControlledBaseType:
-    //
-    // Generally assume fixed base, then assess semantic information
-    ControlledBaseType = BASE_TYPE::FIXED;
-    // If there is a virtual joint, we need to check in detail whether it is a
-    // planar or floating base
-    if (Model->getSRDF()->getVirtualJoints().size() > 0) {
-      std::string world_joint = Model->getSRDF()->getVirtualJoints()[0].name_;
-
-      // A floating base in KinematicTree always contains trans_x, trans_y,
-      // trans_z, rot_x, rot_y, rot_z (XYZRPY, 6-DoF)
-      if (std::find(ControlledJointsNames.begin(),
-                    ControlledJointsNames.end(),
-                    world_joint + "/trans_x") != ControlledJointsNames.end())
-        ControlledBaseType = BASE_TYPE::FLOATING;
-      // A planar base in Kinematica always contains x, y, theta (3-DoF)
-      else if (std::find(ControlledJointsNames.begin(),
-                         ControlledJointsNames.end(),
-                         world_joint + "/theta") !=
-               ControlledJointsNames.end())
-        ControlledBaseType = BASE_TYPE::PLANAR;
+          // The ModelBaseType defined above refers to the base type of the
+          // overall robot model - not of the set of controlled joints. E.g. a
+          // floating-base robot can have a scene defined where the
+          // floating-base virtual joint is _not_ part of the planning
+          // group/scene. Thus we need to establish the BaseType of the joint
+          // group, the ControlledBaseType - if a controlled joint corresponds
+          // to a floating base joint, the ControlledBaseType is the same as the
+          // ModelBaseType.
+          if (Joint->Segment.getJoint().getName() ==
+              RootJoint->getName() + "/trans_x")
+            ControlledBaseType = ModelBaseType;
+        }
     }
 
     setJointLimits();

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -563,34 +563,7 @@ namespace exotica
 
       collision_scene_.reset(new CollisionScene(name_));
 
-      // The BaseType here refers to the base type used in the current Scene,
-      // not of the overall robot model, e.g. a floating-base robot can have a
-      // scene defined where the floating-base virtual joint is _not_ part of
-      // the planning group/scene
-
-      // Generally assume fixed base, then assess semantic information
-      BaseType = BASE_TYPE::FIXED;
-      // If there is a virtual joint, we need to check in detail whether it is a
-      // planar or floating base
-      if (model_->getSRDF()->getVirtualJoints().size() > 0) {
-        std::string world_joint =
-            model_->getSRDF()->getVirtualJoints()[0].name_;
-        std::vector<std::string> planningGroupJointNames =
-            kinematica_.getJointNames();
-
-        // A floating base in Kinematica always contains trans_x, trans_y,
-        // trans_z, rot_x, rot_y, rot_z (XYZRPY, 6-DoF)
-        if (std::find(
-                planningGroupJointNames.begin(), planningGroupJointNames.end(),
-                world_joint + "/trans_x") != planningGroupJointNames.end())
-          BaseType = BASE_TYPE::FLOATING;
-        // A planar base in Kinematica always contains x, y, theta (3-DoF)
-        else if (std::find(planningGroupJointNames.begin(),
-                           planningGroupJointNames.end(),
-                           world_joint + "/theta") !=
-                 planningGroupJointNames.end())
-          BaseType = BASE_TYPE::PLANAR;
-      }
+      BaseType = kinematica_.getControlledBaseType();
 
       if (Server::isRos()) {
         ps_pub_ = Server::advertise<moveit_msgs::PlanningScene>(

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -593,7 +593,7 @@ PYBIND11_MODULE(_pyexotica, module)
     kinematicTree.def("getJointLimits", &KinematicTree::getJointLimits);
     kinematicTree.def("getRootName", &KinematicTree::getRootName);
     kinematicTree.def("getUsedJointLimits", &KinematicTree::getUsedJointLimits);
-    kinematicTree.def("getBaseType", &KinematicTree::getBaseType);
+    kinematicTree.def("getModelBaseType", &KinematicTree::getModelBaseType);
 
     py::class_<KDL::Frame> kdlFrame (module, "KDLFrame");
     kdlFrame.def(py::init());

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -594,6 +594,7 @@ PYBIND11_MODULE(_pyexotica, module)
     kinematicTree.def("getRootName", &KinematicTree::getRootName);
     kinematicTree.def("getUsedJointLimits", &KinematicTree::getUsedJointLimits);
     kinematicTree.def("getModelBaseType", &KinematicTree::getModelBaseType);
+    kinematicTree.def("getControlledBaseType", &KinematicTree::getControlledBaseType);
 
     py::class_<KDL::Frame> kdlFrame (module, "KDLFrame");
     kdlFrame.def(py::init());


### PR DESCRIPTION
This is a follow up to PR #106 which originally fixed the floating base distinction between the _robot model_ and the _controlled joint group_ as well as several other issues. 

This PR focuses on:

- A clean-up of the ``BaseType`` treatment directly in ``KinematicTree`` and moving the logic for the controlled joint group base type as introduced in #106 from ``Scene`` to ``KinematicTree``
- It introduces a clear distinction between the ``ModelBaseType`` and the ``ControlledBaseType``
- A fix for a bug which wrongly set floating base joint limits overriding the joint limits of the controlled group when there was no floating base as part of the controlled group. This was first highlighted when investigating #96  