### PR TITLE
KinematicTree: clear distinction between root joint and root frame

### DIFF
--- a/exotations/task_maps/task_map/src/CoM.cpp
+++ b/exotations/task_maps/task_map/src/CoM.cpp
@@ -187,7 +187,7 @@ namespace exotica
         COM_marker_.scale.z = .02;
         COM_marker_.action = visualization_msgs::Marker::ADD;
 
-        com_marker_.header.frame_id = COM_marker_.header.frame_id = scene_->getRootName();
+        com_marker_.header.frame_id = COM_marker_.header.frame_id = scene_->getRootFrameName();
 
         com_pub_ = Server::advertise<visualization_msgs::Marker>(object_name_ + "coms_marker", 1);
         COM_pub_ = Server::advertise<visualization_msgs::Marker>(object_name_ + "COM_marker", 1);

--- a/exotica/include/exotica/KinematicTree.h
+++ b/exotica/include/exotica/KinematicTree.h
@@ -158,7 +158,8 @@ namespace exotica
             KinematicTree();
             ~KinematicTree() {}
             void Instantiate(std::string JointGroup, robot_model::RobotModelPtr model);
-            std::string getRootName();
+            std::string getRootFrameName();
+            std::string getRootJointName();
             BASE_TYPE getModelBaseType();
             BASE_TYPE getControlledBaseType();
             std::shared_ptr<KinematicResponse> RequestFrames(const KinematicsRequest& request);

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -335,7 +335,8 @@ namespace exotica
       void setCollisionScene(const planning_scene::PlanningSceneConstPtr & scene);
       void setCollisionScene(const moveit_msgs::PlanningSceneConstPtr & scene);
       CollisionScene_ptr & getCollisionScene();
-      std::string getRootName();
+      std::string getRootFrameName();
+      std::string getRootJointName();
       planning_scene::PlanningScenePtr getPlanningScene();
       exotica::KinematicTree & getSolver();
       robot_model::RobotModelPtr getRobotModel();

--- a/exotica/src/KinematicTree.cpp
+++ b/exotica/src/KinematicTree.cpp
@@ -319,7 +319,7 @@ void KinematicTree::publishFrames()
 
         tf::Transform T;
         tf::transformKDLToTF(element->Frame, T);
-        if(i>0) debugTree[i-1] = tf::StampedTransform(T, ros::Time::now(), tf::resolve("exotica",getRootName()), tf::resolve("exotica", element->Segment.getName()));
+        if(i>0) debugTree[i-1] = tf::StampedTransform(T, ros::Time::now(), tf::resolve("exotica",getRootFrameName()), tf::resolve("exotica", element->Segment.getName()));
         i++;
     }
     Server::sendTransform(debugTree);
@@ -328,7 +328,7 @@ void KinematicTree::publishFrames()
     {
         tf::Transform T;
         tf::transformKDLToTF(frame.TempB, T);
-        debugFrames[i*2] = tf::StampedTransform(T, ros::Time::now(), tf::resolve("exotica",getRootName()), tf::resolve("exotica","Frame"+std::to_string(i)+"B"+frame.FrameB->Segment.getName()));
+        debugFrames[i*2] = tf::StampedTransform(T, ros::Time::now(), tf::resolve("exotica",getRootFrameName()), tf::resolve("exotica","Frame"+std::to_string(i)+"B"+frame.FrameB->Segment.getName()));
         tf::transformKDLToTF(frame.TempAB, T);
         debugFrames[i*2+1] = tf::StampedTransform(T, ros::Time::now(), tf::resolve("exotica","Frame"+std::to_string(i)+"B"+frame.FrameB->Segment.getName()), tf::resolve("exotica","Frame"+std::to_string(i)+"A"+frame.FrameA->Segment.getName()));
         i++;
@@ -474,9 +474,14 @@ void KinematicTree::setJointLimits()
   }
 }
 
-std::string KinematicTree::getRootName()
+std::string KinematicTree::getRootFrameName()
 {
   return Tree[0]->Segment.getName();
+}
+
+std::string KinematicTree::getRootJointName()
+{
+  return Model->getRootJoint()->getName();
 }
 
 int KinematicTree::getEffSize()

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -729,9 +729,14 @@ namespace exotica
     return collision_scene_;
   }
 
-  std::string Scene::getRootName()
+  std::string Scene::getRootFrameName()
   {
-    return kinematica_.getRootName();
+    return kinematica_.getRootFrameName();
+  }
+
+  std::string Scene::getRootJointName()
+  {
+    return kinematica_.getRootJointName();
   }
 
   planning_scene::PlanningScenePtr Scene::getPlanningScene()

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -620,7 +620,8 @@ PYBIND11_MODULE(_pyexotica, module)
     py::class_<KinematicTree, std::shared_ptr<KinematicTree>> kinematicTree(kin, "KinematicTree");
     kinematicTree.def("publishFrames", &KinematicTree::publishFrames);
     kinematicTree.def("getJointLimits", &KinematicTree::getJointLimits);
-    kinematicTree.def("getRootName", &KinematicTree::getRootName);
+    kinematicTree.def("getRootFrameName", &KinematicTree::getRootFrameName);
+    kinematicTree.def("getRootJointName", &KinematicTree::getRootJointName);
     kinematicTree.def("getUsedJointLimits", &KinematicTree::getUsedJointLimits);
     kinematicTree.def("getModelBaseType", &KinematicTree::getModelBaseType);
     kinematicTree.def("getControlledBaseType", &KinematicTree::getControlledBaseType);


### PR DESCRIPTION
- Renames getRootName to getRootFrameName
- Adds getRootJointName

E.g. needed when trying to use the root joint name to retrieve the name of the floating base DoF names when combining with other libraries.