### PR TITLE
Minor changes required for the HDRM task map

### DIFF
--- a/exotations/solvers/aico/src/AICOsolver.cpp
+++ b/exotations/solvers/aico/src/AICOsolver.cpp
@@ -131,6 +131,7 @@ namespace exotica
 
   void AICOsolver::Solve(const std::vector<Eigen::VectorXd>& q_init, Eigen::MatrixXd & solution)
   {
+    prob_->preupdate();
     prob_->setStartState(q_init[0]);
     prob_->applyStartState();
     Timer timer;

--- a/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
+++ b/exotations/solvers/ik_solver/src/ik_solver/IKSolver.cpp
@@ -132,6 +132,8 @@ namespace exotica
     {
         Timer timer;
 
+        prob_->preupdate();
+
         if(!prob_) throw_named("Solver has not been initialized!");
         Eigen::VectorXd q0 = prob_->applyStartState();
 

--- a/exotations/solvers/ompl_solver/src/OMPLsolver.cpp
+++ b/exotations/solvers/ompl_solver/src/OMPLsolver.cpp
@@ -74,6 +74,7 @@ namespace exotica
 
   void OMPLsolver::Solve(Eigen::MatrixXd & solution)
   {
+    prob_->preupdate();
     Eigen::VectorXd q0 = prob_->applyStartState();
     setGoalState(prob_->goal_);
     if (base_solver_->solve(q0, solution))

--- a/exotica/include/exotica/PlanningProblem.h
+++ b/exotica/include/exotica/PlanningProblem.h
@@ -63,6 +63,7 @@ namespace exotica
         Eigen::VectorXd getStartState();
         Eigen::VectorXd applyStartState();
         int N;
+        virtual void preupdate();
 
     protected:
         Scene_ptr scene_;

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -337,7 +337,7 @@ namespace exotica
       CollisionScene_ptr & getCollisionScene();
       std::string getRootFrameName();
       std::string getRootJointName();
-      std::string getRobotRootName();
+      std::string getModelRootLinkName();
       planning_scene::PlanningScenePtr getPlanningScene();
       exotica::KinematicTree & getSolver();
       robot_model::RobotModelPtr getRobotModel();

--- a/exotica/include/exotica/Scene.h
+++ b/exotica/include/exotica/Scene.h
@@ -337,6 +337,7 @@ namespace exotica
       CollisionScene_ptr & getCollisionScene();
       std::string getRootFrameName();
       std::string getRootJointName();
+      std::string getRobotRootName();
       planning_scene::PlanningScenePtr getPlanningScene();
       exotica::KinematicTree & getSolver();
       robot_model::RobotModelPtr getRobotModel();

--- a/exotica/include/exotica/TaskMap.h
+++ b/exotica/include/exotica/TaskMap.h
@@ -75,6 +75,8 @@ namespace exotica
 
       virtual int taskSpaceJacobianDim() { return taskSpaceDim();}
 
+      virtual void preupdate() {}
+
       virtual std::vector<TaskVectorEntry> getLieGroupIndices() {return std::vector<TaskVectorEntry>();}
 
       void taskSpaceDim(int & task_dim);

--- a/exotica/init/UnconstrainedTimeIndexedProblem.in
+++ b/exotica/init/UnconstrainedTimeIndexedProblem.in
@@ -5,3 +5,4 @@ Optional double Qrate = 1.0;
 Optional double Hrate = 1.0;
 Optional double Wrate = 1.0;
 Optional Eigen::VectorXd W = Eigen::VectorXd();
+Optional Eigen::VectorXd Rho = Eigen::VectorXd();

--- a/exotica/resources/configs/aico_solver_demo.xml
+++ b/exotica/resources/configs/aico_solver_demo.xml
@@ -13,7 +13,7 @@
   <UnconstrainedTimeIndexedProblem Name="MyProblem">
 
     <PlanningScene>
-      <Scene Name="AICOSolverDemoScene">
+      <Scene>
         <JointGroup>arm</JointGroup>
         <URDF>{exotica}/resources/robots/lwr_simplified.urdf</URDF>
         <SRDF>{exotica}/resources/robots/lwr_simplified.srdf</SRDF>
@@ -22,7 +22,6 @@
 
     <Maps>
       <EffFrame Name="Frame">
-        <Scene>MyScene</Scene>
         <Type>RPY</Type>
         <EndEffector>
             <Frame Link="lwr_arm_6_link" LinkOffset="0 0 0 0.7071067811865476 -4.3297802811774664e-17  0.7071067811865475 4.3297802811774664e-17" BaseOffset="0.4 -0.1 0.5 0 0 0 1" />

--- a/exotica/resources/configs/aico_solver_demo_eight.xml
+++ b/exotica/resources/configs/aico_solver_demo_eight.xml
@@ -13,7 +13,7 @@
   <UnconstrainedTimeIndexedProblem Name="MyProblem">
 
     <PlanningScene>
-      <Scene Name="AICOSolverDemoScene">
+      <Scene>
         <JointGroup>arm</JointGroup>
         <URDF>{exotica}/resources/robots/lwr_simplified.urdf</URDF>
         <SRDF>{exotica}/resources/robots/lwr_simplified.srdf</SRDF>
@@ -22,7 +22,6 @@
 
     <Maps>
       <EffFrame Name="Frame">
-        <Scene>AICOSolverDemoScene</Scene>
         <EndEffector>
             <Frame Link="lwr_arm_6_link" LinkOffset="0 0 0.2 0.7071067811865476 -4.3297802811774664e-17  0.7071067811865475 4.3297802811774664e-17" BaseOffset="0.6 -0.1 0.5 0 0 0 1" />
         </EndEffector>
@@ -36,5 +35,4 @@
     <Wrate>1e4</Wrate>
     <W> 7 6 5 4 3 2 1 </W>
   </UnconstrainedTimeIndexedProblem>
-
 </PlannerDemoConfig>

--- a/exotica/resources/configs/ompl_solver_demo.xml
+++ b/exotica/resources/configs/ompl_solver_demo.xml
@@ -9,7 +9,7 @@
   <SamplingProblem Name="MyProblem">
 
     <PlanningScene>
-      <Scene Name="OMPLSolverDemoScene">
+      <Scene>
         <!-- Computing distances is enabled by default, disable for a Sampling problem by setting the PlanningMode to speed up Scene updates -->
         <PlanningMode>Sampling</PlanningMode>
         <JointGroup>arm</JointGroup>

--- a/exotica/src/PlanningProblem.cpp
+++ b/exotica/src/PlanningProblem.cpp
@@ -56,6 +56,11 @@ namespace exotica
       return scene_->getControlledState();
   }
 
+  void PlanningProblem::preupdate()
+  {
+      for (auto& it : TaskMaps) it.second->preupdate();
+  }
+
   void PlanningProblem::setStartState(Eigen::VectorXdRefConst x)
   {
       if(x.rows()==startState.rows())

--- a/exotica/src/PlanningProblem.cpp
+++ b/exotica/src/PlanningProblem.cpp
@@ -102,6 +102,7 @@ namespace exotica
       scene_.reset(new Scene());
       scene_->InstantiateInternal(SceneInitializer(init.PlanningScene));
       startState = Eigen::VectorXd::Zero(scene_->getModelJointNames().size());
+      N = scene_->getSolver().getNumJoints();
 
       if(init.StartState.rows()>0)
       {

--- a/exotica/src/Problems/SamplingProblem.cpp
+++ b/exotica/src/Problems/SamplingProblem.cpp
@@ -42,7 +42,6 @@ namespace exotica
   SamplingProblem::SamplingProblem()
   {
     Flags = KIN_FK;
-    N = 0;
   }
 
   SamplingProblem::~SamplingProblem()
@@ -63,8 +62,6 @@ namespace exotica
       {
           local_planner_config_ = init.LocalPlannerConfig;
       }
-
-      N = scene_->getSolver().getNumJoints();
 
       goal_ = init.Goal;
 

--- a/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedEndPoseProblem.cpp
@@ -60,8 +60,6 @@ namespace exotica
             JN += Tasks[i]->LengthJ;
         }
 
-        N = scene_->getSolver().getNumJoints();
-
         Rho = Eigen::VectorXd::Ones(NumTasks);
         y.setZero(PhiN);
         W = Eigen::MatrixXd::Identity(N, N);

--- a/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
+++ b/exotica/src/Problems/UnconstrainedTimeIndexedProblem.cpp
@@ -90,7 +90,26 @@ namespace exotica
       H = Eigen::MatrixXd::Identity(N, N)*Q_rate;
       Q = Eigen::MatrixXd::Identity(N, N)*H_rate;
 
-      Rho.assign(T, Eigen::VectorXd::Ones(NumTasks));
+      if(init.Rho.rows()==0)
+      {
+          Rho.assign(T, Eigen::VectorXd::Ones(NumTasks));
+      }
+      else if(init.Rho.rows()==NumTasks)
+      {
+          Rho.assign(T, init.Rho);
+      }
+      else if(init.Rho.rows()==NumTasks*T)
+      {
+          Rho.resize(T);
+          for(int i=0;i<T;i++)
+          {
+              Rho[i] = init.Rho.segment(i*NumTasks,NumTasks);
+          }
+      }
+      else
+      {
+          throw_named("Invalid task weights rho! "<<init.Rho.rows());
+      }
       yref.setZero(PhiN);
       y.assign(T, yref);
       Phi = y;

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -739,6 +739,11 @@ namespace exotica
     return kinematica_.getRootJointName();
   }
 
+  std::string Scene::getRobotRootName()
+  {
+    return model_->getRootLinkName();
+  }
+
   planning_scene::PlanningScenePtr Scene::getPlanningScene()
   {
     return collision_scene_->getPlanningScene();

--- a/exotica/src/Scene.cpp
+++ b/exotica/src/Scene.cpp
@@ -739,7 +739,7 @@ namespace exotica
     return kinematica_.getRootJointName();
   }
 
-  std::string Scene::getRobotRootName()
+  std::string Scene::getModelRootLinkName()
   {
     return model_->getRootLinkName();
   }

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -619,9 +619,9 @@ PYBIND11_MODULE(_pyexotica, module)
     scene.def("loadSceneFile", &Scene::loadSceneFile);
     scene.def("getScene", &Scene::getScene);
     scene.def("getRootName", &Scene::getRootName);
-    scene.def("getRobotRootName", &Scene::getRobotRootName);
 
     scene.def("cleanScene", &Scene::cleanScene);
+    scene.def("getModelRootLinkName", &Scene::getModelRootLinkName);
 
     py::module kin = module.def_submodule("Kinematics","Kinematics submodule.");
     py::class_<KinematicTree, std::shared_ptr<KinematicTree>> kinematicTree(kin, "KinematicTree");

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -615,12 +615,8 @@ PYBIND11_MODULE(_pyexotica, module)
       }
       return py::make_tuple(d, p1, p2);
     });
-    scene.def("loadScene", &Scene::loadScene);
-    scene.def("loadSceneFile", &Scene::loadSceneFile);
-    scene.def("getScene", &Scene::getScene);
     scene.def("getRootName", &Scene::getRootName);
 
-    scene.def("cleanScene", &Scene::cleanScene);
     scene.def("getModelRootLinkName", &Scene::getModelRootLinkName);
 
     py::module kin = module.def_submodule("Kinematics","Kinematics submodule.");

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -615,6 +615,13 @@ PYBIND11_MODULE(_pyexotica, module)
       }
       return py::make_tuple(d, p1, p2);
     });
+    scene.def("loadScene", &Scene::loadScene);
+    scene.def("loadSceneFile", &Scene::loadSceneFile);
+    scene.def("getScene", &Scene::getScene);
+    scene.def("getRootName", &Scene::getRootName);
+    scene.def("getRobotRootName", &Scene::getRobotRootName);
+
+    scene.def("cleanScene", &Scene::cleanScene);
 
     py::module kin = module.def_submodule("Kinematics","Kinematics submodule.");
     py::class_<KinematicTree, std::shared_ptr<KinematicTree>> kinematicTree(kin, "KinematicTree");

--- a/exotica_python/src/Exotica.cpp
+++ b/exotica_python/src/Exotica.cpp
@@ -615,8 +615,8 @@ PYBIND11_MODULE(_pyexotica, module)
       }
       return py::make_tuple(d, p1, p2);
     });
-    scene.def("getRootName", &Scene::getRootName);
-
+    scene.def("getRootFrameName", &Scene::getRootFrameName);
+    scene.def("getRootJointName", &Scene::getRootJointName);
     scene.def("getModelRootLinkName", &Scene::getModelRootLinkName);
 
     py::module kin = module.def_submodule("Kinematics","Kinematics submodule.");


### PR DESCRIPTION
- ```preupdate``` method gets called once at the beginning of ```solve```. This can be used to run one off jobs on problems and solvers.
- Added ```Rho``` to the ```UnconstrainedTimeIndexedProblemInitializer```.
- Cleaned up example configs.
- Added method to retrieve robot root, e.g. `scene_root='world_frame'`, `robot_root='base'`.
- Moved initialization of N from specific problems to the abstract ```PlanningProblem```.