### PR TITLE
Fix OMPLStateValidityChecker safety margin damping

### DIFF
--- a/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLBaseStateSpace.h
+++ b/exotations/solvers/ompl_imp_solver/include/ompl_imp_solver/OMPLBaseStateSpace.h
@@ -70,9 +70,10 @@ namespace exotica
       virtual bool isValid(const ompl::base::State *state) const;
 
       virtual bool isValid(const ompl::base::State *state, double &dist) const;
+
+      double margin_;
     protected:
       SamplingProblem_ptr prob_;
-      double margin_;
       bool self_collision_;
   };
 

--- a/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLBaseStateSpace.cpp
+++ b/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLBaseStateSpace.cpp
@@ -48,7 +48,8 @@ namespace exotica
     margin_ = init.Margin;
     self_collision_ = init.SelfCollisionCheck;
 
-    HIGHLIGHT_NAMED("OMPLStateValidityChecker", "Safety Margin: " << margin_);
+    HIGHLIGHT_NAMED("OMPLStateValidityChecker",
+                    "Initial Safety Margin: " << margin_);
   }
 
   bool OMPLStateValidityChecker::isValid(const ompl::base::State *state) const

--- a/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLImpSolver.cpp
+++ b/exotations/solvers/ompl_imp_solver/src/ompl_imp_solver/OMPLImpSolver.cpp
@@ -90,6 +90,7 @@ namespace exotica
       }
       margin_ = init_.Margin;
       timeout_ = init_.Timeout;
+      HIGHLIGHT("Planning timeout: " << timeout_);
   }
 
   void OMPLImpSolver::specifyProblem(const SamplingProblem_ptr &prob)

--- a/exotations/solvers/ompl_solver/init/OMPLsolver.in
+++ b/exotations/solvers/ompl_solver/init/OMPLsolver.in
@@ -2,4 +2,4 @@ extend <exotica/MotionSolver>
 Required std::string Solver;
 Optional std::string Range = "1";
 Optional bool Smooth = true;
-Optional double Margin = 0.01;
+Optional double Margin = 2.0;


### PR DESCRIPTION
The ``OMPLImpSolver`` reduced the safety margin when setting/checking the goal state to account for a high default value (2m), however, this value wasn't set in the ``OMPLStateValidityChecker`` but only locally, i.e. was never used and lead to high planning failures if the initial value was set too high for the problem in question. This PR resolves this and changes the default margin back to 2.0 (reduced in #115).

**However,** there is no further damping during sampling which may lead to further planning failures down the road, e.g. if the goal state is fine with a damped safety margin X but to get there we would need a lower safety margin. In the end, we may not gain much from the damping at all and should just have a lower default safety margin or rely on the user to set it (it's a sort of hidden failure mode?).

Resolves #116 